### PR TITLE
chore: update beta banner with accurate work-in-progress warning

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -31,7 +31,7 @@
     "appearance": "dark"
   },
   "banner": {
-    "content": "🚀 New: Check out our revamped documentation!",
+    "content": "⚠️ **Beta Docs** – Landing page, Webhooks, and NEAR docs are ready. Release Notes, SDK tab, API Features, and Use Cases sections are still being revised. [View stable docs →](https://docs.request.network)",
     "dismissible": true
   },
   "navigation": {


### PR DESCRIPTION
## PR Description

### Problem
The current banner message "🚀 New: Check out our revamped documentation!" doesn't adequately warn visitors that these beta docs are incomplete. Users may not realize that large sections (Release Notes, SDK tab, API Features, Use Cases) still contain AI slop or are mostly empty.

### Proposed Solution
Replace the banner with a clear beta warning that:
- States upfront that this is a work-in-progress
- Highlights what's actually ready (Landing page, Webhooks, NEAR docs)
- Warns about incomplete sections (Release Notes, SDK tab, API Features, Use Cases)
- Provides escape route to stable docs at docs.request.network

### Considerations
Banner remains dismissible so users actively working with beta content can hide it after first view.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation banner to communicate beta status, indicating which sections are ready (landing page, webhooks, NEAR docs) and which are under revision (release notes, SDK tab, API features, use cases), with a link to stable documentation for users preferring established content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->