### PR TITLE
Add Google Analytics 4 integration for beta docs

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -216,6 +216,11 @@
       "vscode"
     ]
   },
+  "integrations": {
+    "ga4": {
+      "measurementId": "G-F4XSSNMEN6"
+    }
+  },
   "footer": {
     "socials": {
       "x": "https://x.com/RequestNetwork",


### PR DESCRIPTION
# Problem

Beta docs at https://beta.docs.request.network are publicly accessible but not tracked in analytics. Missing data on usage patterns, user journeys from website to docs, and engagement metrics during beta phase.

# Proposed Solution

Add GA4 integration to `docs.json` using the same measurement ID as the main website property. This enables:
- Unified tracking across `request.network` and `beta.docs.request.network`
- Seamless path exploration from website to docs
- Historical data collection during beta to inform structural decisions
- Easy filtering by hostname to separate website vs. docs traffic

# Considerations

- Uses single GA4 data stream approach (not separate stream) to maintain user journey continuity
- Measurement ID is public and safe to commit (visible in client-side code anyway)
- GA4 takes 2-3 days to show data in reports; use GA Debugger for immediate verification
- When migrating to production `docs.request.network`, same measurement ID maintains data continuity

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added Google Analytics 4 integration to track user activity and engagement metrics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->