### PR TITLE
fix: make beta docs banner non-dismissible

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -32,7 +32,7 @@
   },
   "banner": {
     "content": "⚠️ **Beta Docs** – Welcome page, Payment Demo, Webhooks, and NEAR docs are ready. Use Cases, API, Resources, SDK, and Release Notes are still being revised. [View stable docs →](https://docs.request.network)",
-    "dismissible": true
+    "dismissible": false
   },
   "navigation": {
     "tabs": [


### PR DESCRIPTION
# Problem
Mintlify's banner dismissal is permanent (stored in browser data). Once users dismiss the beta docs banner, they never see it again, meaning they:
- May not realize they're viewing beta documentation on subsequent visits
- Lose consistent access to the "View stable docs" link

# Proposed Solution
Changed `dismissible: false` so the beta banner persists across all sessions, ensuring users always have context about documentation status and access to stable docs alternative.

# Considerations
- Trade-off: Slight increase in visual clutter vs. critical context preservation
- Future: Remove banner entirely once beta period ends
- Feature request to Mintlify: Add session-based dismissal option (`dismissible: "session"`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * The beta banner is now permanently visible and cannot be dismissed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->