### PR TITLE
chore: update CTA from book a call to get in touch, add .gitignore entry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /ignore
+/.ignore

--- a/request-network-api/create-and-pay-requests.mdx
+++ b/request-network-api/create-and-pay-requests.mdx
@@ -9,9 +9,9 @@ description: "The Request Network API provides an interface for creating and pay
 </Warning>
 
 <Info>
-**Talk to an expert**
+**Reach out**
 
-Discover how Request Network API can enhance your app's features - [book a call](https://calendly.com/mariana-rn/request-network-demo-docs) with us.
+For more details on how to start accepting crypto payments, [get in touch](https://2deywy.share-eu1.hsforms.com/2b92phs9LR_eJdeZoxzmoMA?utm_source=request.network&utm_medium=docs&utm_campaign=evergreen&utm_content=get_in_touch) and we will reach out.
 </Info>
 
 ## **Core Functionality**

--- a/request-network-api/easyinvoice-api-demo-app.mdx
+++ b/request-network-api/easyinvoice-api-demo-app.mdx
@@ -10,9 +10,9 @@ description: "An app for creating and paying requests using the Request Network 
 EasyInvoice is a web application built with Next.js that allows users to create and manage invoices, and accept crypto payments via the Request Network API. It mimics Web2 apps in its functionalities, providing a user-friendly experience with Google login and real-time updates.
 
 <Info>
-**Talk to an expert**
+**Reach out**
 
-Discover how your app can have its own EasyInvoice features - [book a call](https://calendly.com/mariana-rn/request-network-demo-docs) with us.
+For more details on how to start accepting crypto payments, [get in touch](https://2deywy.share-eu1.hsforms.com/2b92phs9LR_eJdeZoxzmoMA?utm_source=request.network&utm_medium=docs&utm_campaign=evergreen&utm_content=get_in_touch) and we will reach out.
 
 </Info>
 <CardGroup>


### PR DESCRIPTION
## Problem
The current CTAs in documentation use "Book a Call" with Calendly links, which needs to be updated to a unified "Get in Touch" messaging with HubSpot form URLs.

## Proposed Solution
- Updated 2 documentation pages to use "Reach out" / "get in touch" CTA messaging
- Replaced Calendly booking links with HubSpot form URL including UTM tracking parameters

## Secondary Changes
- Added `/.ignore` pattern to `.gitignore` to exclude local development files

Fixes RequestNetwork/public-issues#67