### PR TITLE
docs: Fix token list structure documentation

### DIFF
--- a/resources/token-list.mdx
+++ b/resources/token-list.mdx
@@ -14,7 +14,7 @@ The token list is available at: [https://requestnetwork.github.io/request-token-
 
 You can fetch the token list directly in your application:
 
-```bash 
+```typescript
 const tokenList = await fetch(
   "https://requestnetwork.github.io/request-token-list/latest.json"
 ).then((res) => res.json());
@@ -24,17 +24,33 @@ const tokenList = await fetch(
 
 Each token in the list contains the following information:
 
-```bash
+```json
 {
-  "id": "TKN-mainnet",
-  "name": "Token Name",
-  "address": "0x...",
-  "symbol": "TKN",
-  "decimals": 18,
-  "chainId": 1,
-  "logoURI": "https://..."
+  "id": "USDC-mainnet",
+  "name": "USD Coin",
+  "symbol": "USDC",
+  "decimals": 6,
+  "address": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+  "network": "mainnet",
+  "type": "ERC20",
+  "hash": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+  "chainId": 1
 }
 ```
+
+| Field | Description |
+|-------|-------------|
+| `id` | Unique identifier, typically `SYMBOL-network` (e.g., `USDC-mainnet`) |
+| `name` | Human-readable token name |
+| `symbol` | Token symbol |
+| `decimals` | Number of decimal places |
+| `address` | Token contract address |
+| `network` | Network name (e.g., `mainnet`, `matic`, `bsc`) |
+| `type` | Currency type (e.g., `ERC20`, `ETH`, `ISO4217`) |
+| `hash` | For ERC20 tokens, same as `address`. For native tokens, a calculated hash. |
+| `chainId` | Chain ID of the network |
+
+See the [SDK source code](https://github.com/RequestNetwork/requestNetwork/blob/master/packages/types/src/currency-types.ts) for the full list of supported networks and types.
 
 ## Adding a New Token
 


### PR DESCRIPTION
## Problem

The token list documentation has incomplete/incorrect token structure:
- Missing required fields: `network`, `type`, `hash`
- Included non-existent field: `logoURI`
- Code blocks using wrong language (`bash` instead of `typescript`/`json`)

Closes RequestNetwork/request-token-list#7

## Proposed Solution

- Complete token structure example using real USDC token
- Field descriptions table explaining each field
- Link to SDK source code for supported `network` and `type` values
- Fixed code block languages

🤖 Generated with [Claude Code](https://claude.com/claude-code)