### PR TITLE
docs: remove release notes section and streamline use cases to core features

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -51,10 +51,7 @@
             "pages": [
               "use-cases/payment-detection",
               "use-cases/invoicing",
-              "use-cases/payouts",
-              "use-cases/payroll",
-              "use-cases/checkout",
-              "use-cases/subscriptions"
+              "use-cases/checkout"
             ]
           }
         ]
@@ -176,19 +173,6 @@
             "group": "🔧 SDK Documentation",
             "pages": [
               "sdk-legacy/overview"
-            ]
-          }
-        ]
-      },
-      {
-        "tab": "Release Notes",
-        "groups": [
-          {
-            "group": "📋 Release Notes",
-            "pages": [
-              "release-notes/index",
-              "release-notes/request-api",
-              "release-notes/easy-invoice"
             ]
           }
         ]

--- a/use-cases/payment-processing-demo.mdx
+++ b/use-cases/payment-processing-demo.mdx
@@ -42,6 +42,14 @@ import { DemoContainer } from '/snippets/demo-container.jsx'
   <div style={{ marginBottom: '0.5rem' }}>
     <CardGroup cols={3}>
       <Card 
+        title="🔍 Payment Detection" 
+        href="/use-cases/payment-detection"
+        icon="magnifying-glass-dollar"
+      >
+        Track incoming payments automatically and reconcile transactions in real time
+      </Card>
+
+      <Card 
         title="📄 Invoicing" 
         href="/use-cases/invoicing"
         icon="file-invoice"
@@ -50,19 +58,11 @@ import { DemoContainer } from '/snippets/demo-container.jsx'
       </Card>
       
       <Card 
-        title="💸 Payouts" 
-        href="/use-cases/payouts"
-        icon="money-bill-transfer"
+        title="🛒 Checkout" 
+        href="/use-cases/checkout"
+        icon="cart-shopping"
       >
-        Send batch payments to multiple recipients with automatic tracking
-      </Card>
-
-      <Card 
-        title="💰 Payroll" 
-        href="/use-cases/payroll"
-        icon="users"
-      >
-        Pay your team in crypto with automated payroll runs
+        Accept crypto payments in your checkout flow with built-in request tracking
       </Card>
     </CardGroup>
   </div>

--- a/use-cases/welcome.mdx
+++ b/use-cases/welcome.mdx
@@ -64,12 +64,12 @@ import { DemoContainer } from '/snippets/demo-container.jsx'
         href="/use-cases/payment-detection"
         icon="briefcase"
       >
-        Explore specific business scenarios: payment detection, invoicing, payouts, payroll, checkout, and subscriptions
+        Explore specific business scenarios: payment detection, invoicing, and checkout
       </Card>
       
       <Card 
         title="API Features" 
-        href="/api-features/payment-types"
+        href="/api-features/payment-types-overview"
         icon="code"
       >
         The easiest way to integrate. Payment types, webhooks, and developer tools.
@@ -78,7 +78,7 @@ import { DemoContainer } from '/snippets/demo-container.jsx'
   </div>
 
   <div style={{ marginBottom: '3rem' }}>
-    <CardGroup cols={3}>
+    <CardGroup cols={2}>
       <Card 
         title="🌐 Resources" 
         href="/resources/supported-chains-and-currencies"
@@ -88,18 +88,10 @@ import { DemoContainer } from '/snippets/demo-container.jsx'
       </Card>
       <Card 
         title="SDK (Legacy)" 
-        href="/sdk-legacy/migration-guide"
+        href="/sdk-legacy/overview"
         icon="clock"
       >
         Legacy SDK and protocol documentation for advanced users
-      </Card>
-      
-      <Card 
-        title="📋 Release Notes" 
-        href="/release-notes/index"
-        icon="newspaper"
-      >
-        Stay updated with the latest features and improvements
       </Card>
     </CardGroup>
   </div>


### PR DESCRIPTION
### TL;DR

Streamlined documentation navigation by removing unused use cases and sections while updating card layouts and links.

### What changed?

- Removed payouts, payroll, and subscriptions use cases from the navigation menu
- Eliminated the entire "Release Notes" tab and its associated pages
- Added payment detection card to the payment processing demo page
- Updated card layouts from 3-column to 2-column grid on the welcome page
- Fixed broken API features link to point to the correct endpoint
- Updated SDK legacy link to point to overview instead of migration guide

### How to test?

1. Navigate through the documentation to verify all links work correctly
2. Check that the use cases section only shows payment detection, invoicing, and checkout
3. Confirm the Release Notes tab no longer appears in the navigation
4. Verify the welcome page displays cards in a 2-column layout
5. Test that the API Features card links to `/api-features/payment-types-overview`

### Why make this change?

This change focuses the documentation on the core supported use cases and removes incomplete or outdated sections, providing users with a cleaner navigation experience and ensuring all links point to existing content.