### PR TITLE
docs(resources): remove community page from navigation

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -142,8 +142,7 @@
             "pages": [
               "resources/supported-chains-and-currencies",
               "resources/near-blockchain",
-              "resources/token-list",
-              "resources/community"
+              "resources/token-list"
             ]
           },
           {


### PR DESCRIPTION
### TL;DR

Removed the "community" page from the resources section in the documentation navigation.

### What changed?

The `resources/community` page entry has been removed from the pages array in the resources section of `docs.json`.

### How to test?

1. Build and serve the documentation locally
2. Navigate to the resources section
3. Verify that the community page is no longer listed in the navigation menu
4. Confirm that the remaining pages (supported-chains-and-currencies, near-blockchain, token-list) are still accessible

### Why make this change?

This change streamlines the resources section by removing the community page reference, likely because the page is no longer needed or has been relocated elsewhere in the documentation structure.