### PR TITLE
docs: remove beta banner and legacy SDK tab

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -30,10 +30,6 @@
   "thumbnails": {
     "appearance": "dark"
   },
-  "banner": {
-    "content": "⚠️ **Beta Docs** – Welcome page, Payment Demo, Webhooks, and NEAR docs are ready. Use Cases, API, Resources, SDK, and Release Notes are still being revised. [View stable docs →](https://docs.request.network)",
-    "dismissible": false
-  },
   "navigation": {
     "tabs": [
       {
@@ -163,17 +159,6 @@
             "pages": [
               "faq",
               "glossary"
-            ]
-          }
-        ]
-      },
-      {
-        "tab": "SDK (Legacy)",
-        "groups": [
-          {
-            "group": "🔧 SDK Documentation",
-            "pages": [
-              "sdk-legacy/overview"
             ]
           }
         ]


### PR DESCRIPTION
### TL;DR

Removed the beta warning banner and legacy SDK documentation section from the docs configuration.

### What changed?

- Removed the beta warning banner that displayed "⚠️ **Beta Docs** – Welcome page, Payment Demo, Webhooks, and NEAR docs are ready. Use Cases, API, Resources, SDK, and Release Notes are still being revised. [View stable docs →](https://docs.request.network)"
- Eliminated the "SDK (Legacy)" tab and its associated "🔧 SDK Documentation" group containing the legacy overview page

### How to test?

1. Build and serve the documentation locally
2. Verify the beta warning banner no longer appears at the top of pages
3. Confirm the "SDK (Legacy)" tab is no longer visible in the navigation
4. Check that all remaining navigation tabs and pages load correctly

### Why make this change?

The documentation has likely moved out of beta status, making the warning banner obsolete. The legacy SDK documentation removal suggests a transition to newer SDK versions, streamlining the documentation structure by removing outdated content.