### PR TITLE
docs: add Connect AI Tools setup with MCP

### DIFF
--- a/api-setup/connect-ai-tools.mdx
+++ b/api-setup/connect-ai-tools.mdx
@@ -1,0 +1,103 @@
+---
+title: "Connect AI Tools"
+description: "Connect Claude Code or Cursor to Request Network docs via MCP for live, queryable documentation access."
+---
+
+## Overview
+
+Give your AI coding tools live access to Request Network docs. Once connected via MCP, your tool can search current documentation in real time instead of relying on stale snapshots.
+
+## What is MCP?
+
+The Model Context Protocol (MCP) is an open standard that lets AI applications connect to external tools and data sources in a consistent way.
+
+When you connect docs through MCP, your assistant can query:
+
+- Latest documentation content
+- Updated endpoint details
+- Current integration guides and examples
+
+## MCP server URL
+
+Use:
+
+```text
+https://requestnetwork.mintlify.app/mcp
+```
+
+## Claude Code
+
+<Steps>
+  <Step title="Add the MCP server">
+    Run:
+
+    ```bash
+    claude mcp add --transport http request-network-docs https://requestnetwork.mintlify.app/mcp
+    ```
+  </Step>
+  <Step title="Verify the connection">
+    List configured MCP servers:
+
+    ```bash
+    claude mcp list
+    ```
+
+    You should see `request-network-docs`.
+  </Step>
+  <Step title="Test a docs-grounded question">
+    In Claude Code, ask:
+
+    ```text
+    How do I create a secure payment link and process webhook events?
+    ```
+  </Step>
+</Steps>
+
+## Cursor
+
+<Steps>
+  <Step title="Open MCP settings">
+    In Cursor, open MCP settings and add a new server.
+  </Step>
+  <Step title="Configure server">
+    Use:
+
+    - **Name**: `request-network-docs`
+    - **Transport**: `HTTP`
+    - **URL**: `https://requestnetwork.mintlify.app/mcp`
+  </Step>
+  <Step title="Validate in chat">
+    Ask a question about Request Network APIs and confirm the answer is grounded in docs content.
+  </Step>
+</Steps>
+
+## Scripts and `llms.txt`
+
+If you are building scripts or pipelines without an MCP client, use:
+
+| URL | Use |
+| --- | --- |
+| `https://requestnetwork.mintlify.app/llms.txt` | Sitemap-style index of pages and descriptions |
+| `https://requestnetwork.mintlify.app/llms-full.txt` | Full documentation in one Markdown file |
+
+Mintlify generates these files on deployment and keeps them in sync with live docs.
+
+## Suggested verification prompts
+
+- "How do I configure webhook signature validation in Request Network?"
+- "What is the difference between secure payments and standard requests?"
+- "Which headers are required when using x-client-id?"
+
+## Related docs
+
+<CardGroup cols={3}>
+  <Card title="Authentication" href="/api-reference/authentication" icon="key">
+    API key and Client ID usage patterns.
+  </Card>
+  <Card title="Webhooks" href="/api-reference/webhooks" icon="webhook">
+    Signature verification, retries, and payloads.
+  </Card>
+  <Card title="Secure Payment Integration Guide" href="/api-features/secure-payment-integration-guide" icon="link">
+    End-to-end wallet + client ID + webhook + payment link flow.
+  </Card>
+</CardGroup>

--- a/docs.json
+++ b/docs.json
@@ -66,6 +66,7 @@
             "group": "🔑 API Setup",
             "pages": [
               "api-setup/getting-started",
+              "api-setup/connect-ai-tools",
               "request-network-api/api-portal-manage-api-keys-and-webhooks",
               "api-setup/migrate-to-v2"
             ]


### PR DESCRIPTION
## Summary
- Add new page: `api-setup/connect-ai-tools`
- Document MCP setup for Claude Code and Cursor
- Add Request Network MCP endpoint and `llms.txt` / `llms-full.txt` links
- Add navigation entry under API Setup in `docs.json`

## Why
Developers increasingly use AI coding tools. This page makes docs grounding setup explicit and copy-paste ready.

## Test plan
- Previewed page in Mintlify dev
- Verified navigation entry appears under API Setup
- Verified links and commands render correctly

Made with [Cursor](https://cursor.com)