### PR TITLE
docs: fix implementation discrepancies across API docs

### DIFF
--- a/api-features/crosschain-payments.mdx
+++ b/api-features/crosschain-payments.mdx
@@ -5,7 +5,7 @@ description: "Multi-network payment routing with automatic bridging and optimiza
 
 ## Overview
 
-Crosschain payments allow users to pay a request using a stablecoin from a different blockchain network than the one specified on the request. For example, a payer can pay a request for USDC on Base using USDT from their Optimism wallet.
+Crosschain payments allow users to pay a request using a stablecoin from a different blockchain network than the one specified on the request. For example, a payer can pay a request for USDC on Base using USDT from their Optimism wallet. Crosschain routing is powered by [LiFi](https://li.fi/), which aggregates bridges and DEXs to find optimal routes.
 
 ## Benefits
 

--- a/api-features/recurring-payments.mdx
+++ b/api-features/recurring-payments.mdx
@@ -68,12 +68,15 @@ sequenceDiagram
 
 Recurring payments are supported on the following blockchain networks:
 
+**Mainnet:**
 - Ethereum
 - Polygon
 - Arbitrum
 - Gnosis
 - Base
 - Binance Smart Chain
+
+**Testnet:**
 - Sepolia
 
 ## Supported currencies

--- a/api-reference/secure-payments.mdx
+++ b/api-reference/secure-payments.mdx
@@ -74,7 +74,7 @@ curl -X POST "https://api.request.network/v2/secure-payments" \
   "requestIds": [
     "01e273ecc29d4b526df3a0f1f05ffc59372af8752c2b678096e49ac270416a7cdb"
   ],
-  "securePaymentUrl": "https://secure.request.network/?token=01ABC123DEF456GHI789JKL",
+  "securePaymentUrl": "https://pay.request.network/?token=01ABC123DEF456GHI789JKL",
   "token": "01ABC123DEF456GHI789JKL"
 }
 ```

--- a/resources/supported-chains-and-currencies.mdx
+++ b/resources/supported-chains-and-currencies.mdx
@@ -11,6 +11,7 @@ Overall, Request Network API supports 500+ currencies across EVM-compatible chai
 
 EVM chains supported for core payment flows include:
 
+**Mainnet:**
 - Ethereum
 - Arbitrum One
 - OP Mainnet
@@ -19,7 +20,11 @@ EVM chains supported for core payment flows include:
 - BSC
 - Avalanche
 - Fantom
+- Gnosis
+- Mantle
 - zkSync Era
+
+**Testnet:**
 - Sepolia
 
 For non-EVM support, Request Network API also supports Tron for USDT TRC-20 payments.

--- a/use-cases/checkout.mdx
+++ b/use-cases/checkout.mdx
@@ -13,7 +13,7 @@ Unlike traditional crypto payments where customers send funds and you manually m
 **What you get:**
 - **Instant attribution** - Every payment automatically linked to the correct order via Request ID
 - **Multi-wallet support** - Accept payments from 80+ wallets via <Tooltip tip="Multi-wallet connection protocol enabling users to connect any supported wallet">WalletConnect</Tooltip>
-- **Multi-currency flexibility** - Accept payments across 9 EVM chains in 150+ currencies
+- **Multi-currency flexibility** - Accept payments across [10+ EVM chains and Tron](/resources/supported-chains-and-currencies) in 500+ currencies
 - **Real-time confirmations** - <Tooltip tip="HTTP callbacks that notify your server when payment events occur">Webhook</Tooltip> notifications for instant order fulfillment
 - **High-volume ready** - Process thousands of orders per day without unique wallet addresses
 

--- a/use-cases/invoicing.mdx
+++ b/use-cases/invoicing.mdx
@@ -6,13 +6,13 @@ description: "Create crypto invoices with automatic payment detection and reconc
 
 ## Overview
 
-Bring instant, verifiable payments to your invoicing flow. Generate invoices in fiat or crypto, let customers pay in their preferred token across 9 EVM chains and 150+ currencies, and receive automatic reconciliation with on-chain payment detection - no manual tracking, no infrastructure overhead.
+Bring instant, verifiable payments to your invoicing flow. Generate invoices in fiat or crypto, let customers pay in their preferred token across [10+ EVM chains and Tron](/resources/supported-chains-and-currencies) in 500+ currencies, and receive automatic reconciliation with on-chain payment detection - no manual tracking, no infrastructure overhead.
 
 **What you get:**
 - **Permanent records** - Invoices stored on <Tooltip tip="InterPlanetary File System - a distributed storage network for permanent data">IPFS</Tooltip> create a tamper-proof audit trail
 - **Multi-currency flexibility** - Invoice in USD, get paid in crypto with automatic conversion
 - **Instant reconciliation** - Every invoice automatically linked to its <Tooltip tip="Blockchain-recorded transaction verified by network validators">on-chain</Tooltip> payment
-- **Cross-chain support** - Accept payments across 9 networks in 150+ currencies
+- **Cross-chain support** - Accept payments across [10+ EVM chains and Tron](/resources/supported-chains-and-currencies) in 500+ currencies
 - **Webhook automation** - Real-time payment confirmations for backend integration
 
 ## Quickstart


### PR DESCRIPTION
Align documentation with actual codebase after cross-referencing
request-api, request-auth-api, request-dashboard, and
request-secure-payment implementations.

- fix secure payment URL from secure.request.network to pay.request.network
- add LiFi as the crosschain bridge provider in crosschain-payments
- update chain counts from "9 EVM chains, 150+ currencies" to
  "10+ EVM chains and Tron, 500+ currencies" in checkout and invoicing
- add missing chains (Gnosis, Mantle) to supported-chains-and-currencies
- separate mainnet and testnet lists in recurring-payments and
  supported-chains-and-currencies