### PR TITLE
docs(content): refresh Tron coverage, batch-payment EVM scope, webhook 12-event list

### DIFF
--- a/api-features/batch-payments.mdx
+++ b/api-features/batch-payments.mdx
@@ -7,6 +7,10 @@ description: "Process multiple payments in a single transaction for gas optimiza
 
 Batch payments enable you to process multiple payment requests efficiently in a single blockchain transaction, reducing gas costs and simplifying multi-recipient workflows.
 
+<Warning>
+**EVM-only.** Batch payments — both inbound (one transaction paying multiple payees) and outbound (one signed batch payout) — are supported on EVM chains only. The API rejects Tron batch requests with `Batch payments are not supported for TRON networks. Please submit individual payment requests.` For Tron, submit single-recipient payments or payouts instead.
+</Warning>
+
 **Two Types of Batch Payments:**
 
 ### Batch Pay Invoices
@@ -187,32 +191,8 @@ Common error scenarios and their solutions:
 - **Invalid Addresses**: Validate all payee addresses before batch submission
 - **Gas Limit Exceeded**: Reduce batch size if hitting network gas limits
 
-## Demo Application
-
-See the batch payment feature in action in our EasyInvoice demo application:
-
-### EasyInvoice Batch Pay Invoices
-
-<iframe
-  className="w-full aspect-video rounded-xl"
-  src="https://www.youtube.com/embed/BsbENNP00AI"
-  title="EasyInvoice Batch Pay Invoices"
-  frameBorder="0"
-  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-  allowFullScreen
-></iframe>
-
-### EasyInvoice: Batch Payouts
-
-<iframe
-  className="w-full aspect-video rounded-xl"
-  src="https://www.youtube.com/embed/craVMSj8PRs"
-  title="EasyInvoice Batch Payouts"
-  frameBorder="0"
-  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-  allowFullScreen
-></iframe>
+## Related
 
 For detailed information on all available endpoints and their parameters, see the full [Request Network API Reference](https://api.request.network/open-api).
 
-For implementation details, see [Batch payouts](/use-cases/batch-payouts).
+For an end-to-end walkthrough of paying many recipients at once, see [Batch payouts](/use-cases/batch-payouts).

--- a/api-features/client-id-management.mdx
+++ b/api-features/client-id-management.mdx
@@ -31,6 +31,15 @@ Orchestrator (with Client ID) → POST /v2/request (no payee field)
   → Payment goes to merchant's configured wallet
 ```
 
+## Two ways to manage Client IDs
+
+| Method | Best for |
+| --- | --- |
+| **Dashboard** ([dashboard.request.network](https://dashboard.request.network)) | Most users — sign in with your wallet, generate a Client ID, set allowed domains, copy the value |
+| **Auth API** (`POST /v1/client-ids`) | Automation, dynamic provisioning, multi-tenant orchestration |
+
+Both paths use the same Client ID — there is no functional difference.
+
 ## CRUD Operations
 
 Client IDs can be managed through the auth API (session-based) or the request API (API key-based).
@@ -66,6 +75,18 @@ Fee recipient address. Required when `feePercentage` is set.
 
 <ParamField body="payeeDestinationId" type="string">
 ERC-7828 destination ID to bind to this Client ID. Enables the orchestrator pattern.
+</ParamField>
+
+<ParamField body="operatorWalletAddress" type="string">
+Optional Ethereum address of a smart wallet with delegated operator permissions. Used in commerce payment (authorize/capture) flows.
+</ParamField>
+
+<ParamField body="defaultPreApprovalExpiry" type="number">
+Default pre-approval duration in seconds. Overrides per-request value when set.
+</ParamField>
+
+<ParamField body="defaultAuthorizationExpiry" type="number">
+Default authorization duration in seconds. Overrides per-request value when set.
 </ParamField>
 
 ```json Response (201)
@@ -107,7 +128,7 @@ curl -X PUT "https://auth.request.network/v1/client-ids/01HXEXAMPLE123" \
   }'
 ```
 
-All fields are optional. You can update `label`, `allowedDomains`, `feePercentage`, `feeAddress`, `payeeDestinationId`, and `status`.
+All fields are optional. You can update `label`, `allowedDomains`, `feePercentage`, `feeAddress`, `payeeDestinationId`, `operatorWalletAddress`, `defaultPreApprovalExpiry`, `defaultAuthorizationExpiry`, and `status`.
 
 ### Revoke a Client ID
 

--- a/api-features/crypto-to-fiat-payments.mdx
+++ b/api-features/crypto-to-fiat-payments.mdx
@@ -72,7 +72,7 @@ This four-step approach is required due to current API limitations - more stream
 Many `/payer` endpoints in the Request Network API require a `clientUserId` as a path parameter. This value is an **arbitrary identifier** chosen by your platform to represent a user (the payer) in your own system.
 
 * **You control the format:** The `clientUserId` can be any unique string that makes sense for your application. It can be a UUID, email address, database ID, or anything unique per user on your platform.
-* **EasyInvoice Example:** In the EasyInvoice demo app, `clientUserId` is set to the user's email address.
+* **Common pattern:** Many integrations set `clientUserId` to the user's email address or an internal user ID.
 * **Why is this useful?** This approach allows you to integrate the Request Network API without having to change your existing user management logic. You simply pass your own identifier to the API, and all payer-related compliance, agreement, and payment detail records will be associated with that value.
 
 **Example usage:**
@@ -181,15 +181,14 @@ RequestAPI-->>Platform: Request created
 
 ### **Design Rationale & UX Constraints**
 
-While it is technically possible to create a crypto-to-fiat request before the payer has completed KYC, EasyInvoice intentionally requires the payer to complete KYC first. This decision is based on several practical and UX considerations:
+While it is technically possible to create a crypto-to-fiat request before the payer has completed KYC, the recommended pattern is to require KYC first. This is based on several practical and UX considerations:
 
-* **Bank Account Association:** The payee’s bank account ("payment details") must be linked to a specific payer, which can only be done after the payer completes KYC. This ensures compliance and accurate association of payment details.
-* **Validation Complexity:** Although the payee could submit their bank account details in advance, the platform cannot validate or approve these details until the payer’s KYC is complete. This would introduce additional communication steps and potential confusion.
-* **UI Simplicity:** EasyInvoice integrates payee bank account registration directly into the Create Invoice form. If the user clicks "Create" before the bank account is approved, a loading indicator appears until approval is granted. This avoids the need for a separate bank account management page and keeps the user experience straightforward.
-* **Protocol Fit**: The crypto-to-fiat feature is integrated at the API level, not at the Request Network protocol level. Creating a request on the protocol does not require bank account details, because the protocol itself only handles crypto payments. The additional bank account and offramp logic is layered on top via the API, which transfers crypto to Request Tech, who then executes the offramp and sends fiat to the payee’s bank account. This separation adds some complexity, so the UI is intentionally kept simple.
-* **Future Flexibility:** While some clients may want to allow payees to create requests before payer KYC, this is not currently supported in EasyInvoice to avoid increased complexity. We may revisit this if there is sufficient market demand.
+* **Bank Account Association:** The payee's bank account ("payment details") must be linked to a specific payer, which can only be done after the payer completes KYC. This ensures compliance and accurate association of payment details.
+* **Validation Complexity:** Although the payee could submit their bank account details in advance, the platform cannot validate or approve these details until the payer's KYC is complete. This would introduce additional communication steps and potential confusion.
+* **UI Simplicity:** Embedding payee bank account registration directly in the request creation form (with a pending state until approval) keeps the UX straightforward and avoids a separate bank account management page.
+* **Protocol Fit:** The crypto-to-fiat feature is integrated at the API level, not at the Request Network protocol level. Creating a request on the protocol does not require bank account details, because the protocol itself only handles crypto payments. The additional bank account and offramp logic is layered on top via the API, which transfers crypto to Request Tech, who then executes the offramp and sends fiat to the payee's bank account.
 
-This approach ensures a smooth, compliant, and user-friendly experience, even if it means some technical possibilities are not exposed in the current UI.
+This approach ensures a smooth, compliant, and user-friendly experience.
 
 ### Relevant Endpoints
 

--- a/api-features/payee-destinations.mdx
+++ b/api-features/payee-destinations.mdx
@@ -42,8 +42,10 @@ The checksum portion (`#ABCD1234`) is generated automatically by the API when yo
   </Step>
 
   <Step title="Create a destination">
-    Call `POST /v1/payee-destination` with the token address and chain ID. The API generates the full destination ID with interop address.
+    Call `POST /v1/payee-destination` with the token address and chain ID. The API generates the full destination ID with interop address. EVM and Tron destinations use the same endpoint and shape — only the address format and chain ID differ.
 
+    <Tabs>
+    <Tab title="EVM (USDC on Base)">
     ```bash
     curl -X POST "https://auth.request.network/v1/payee-destination" \
       -H "Cookie: session=YOUR_SESSION_TOKEN" \
@@ -53,6 +55,19 @@ The checksum portion (`#ABCD1234`) is generated automatically by the API when yo
         "chainId": 8453
       }'
     ```
+    </Tab>
+    <Tab title="Tron (USDT-TRC20)">
+    ```bash
+    curl -X POST "https://auth.request.network/v1/payee-destination" \
+      -H "Cookie: session=YOUR_SESSION_TOKEN" \
+      -H "Content-Type: application/json" \
+      -d '{
+        "tokenAddress": "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t",
+        "chainId": 728126428
+      }'
+    ```
+    </Tab>
+    </Tabs>
   </Step>
 
   <Step title="Use the destination ID">

--- a/api-features/payouts.mdx
+++ b/api-features/payouts.mdx
@@ -14,8 +14,10 @@ Payouts let you initiate payments without a separate request creation step. The 
 
 ## Single Payout
 
-Create a payment request and get transaction calldata in one call.
+Create a payment request and get transaction calldata in one call. Single payouts work on **all 8 supported networks (EVM and Tron)**.
 
+<Tabs>
+<Tab title="EVM (USDC on Base)">
 ```bash
 curl -X POST "https://api.request.network/v2/payouts" \
   -H "x-api-key: YOUR_API_KEY" \
@@ -28,12 +30,28 @@ curl -X POST "https://api.request.network/v2/payouts" \
     "reference": "PAYOUT-001"
   }'
 ```
+</Tab>
+<Tab title="Tron (USDT on Tron)">
+```bash
+curl -X POST "https://api.request.network/v2/payouts" \
+  -H "x-api-key: YOUR_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "amount": "100",
+    "invoiceCurrency": "USD",
+    "paymentCurrency": "USDT-tron",
+    "payee": "TJRabPrwbZy45sbavfcjinPJC18kjpRTv8",
+    "reference": "PAYOUT-001"
+  }'
+```
+</Tab>
+</Tabs>
 
 **Required fields:**
 - `amount` — Human-readable amount
 - `invoiceCurrency` — Invoice currency (e.g., `"USD"`)
-- `paymentCurrency` — Payment currency ID (e.g., `"USDC-base"`)
-- `payee` — Recipient wallet address
+- `paymentCurrency` — Payment currency ID (e.g., `"USDC-base"`, `"USDT-tron"`)
+- `payee` — Recipient wallet address (EVM `0x...` or Tron `T...`)
 
 **Optional fields:**
 - `reference` — Merchant reference for reconciliation
@@ -46,6 +64,10 @@ The response includes `requestId` and a `transactions` array with executable cal
 ## Batch Payout
 
 Pay multiple recipients in a single blockchain transaction. All payments must be on the same network.
+
+<Warning>
+**EVM-only.** Batch payouts work on EVM chains. Tron batch payouts are not supported — the API rejects them with `Batch payments are not supported for TRON networks.` For Tron, submit individual `POST /v2/payouts` calls per recipient.
+</Warning>
 
 ```bash
 curl -X POST "https://api.request.network/v2/payouts/batch" \

--- a/api-features/secure-payment-supported-networks-and-currencies.mdx
+++ b/api-features/secure-payment-supported-networks-and-currencies.mdx
@@ -5,9 +5,23 @@ description: "Chain and currency coverage for Secure Payment Pages."
 
 ## Coverage model
 
-Secure Payment Pages use the same chain and currency coverage as standard Request API request flows.
+Secure Payment Pages support the same 8 networks as Request API destinations:
 
-This means supported options are the networks and currencies available through the API token list and request creation endpoints.
+| Type | Networks |
+| --- | --- |
+| EVM | Ethereum (`mainnet`), Arbitrum One, Optimism, Base, Polygon (`matic`), BNB Smart Chain (`bsc`) |
+| Non-EVM | **Tron** |
+| Testnet | Sepolia |
+
+Stablecoins (USDC, USDT) are supported on every mainnet, including **Tron** (USDT and USDC, TRC-20). FAU is available on Sepolia for testing.
+
+For a payer's perspective, a Secure Payment link can be paid from any of these chains — when the source chain differs from the merchant's destination chain, the swap is routed through Li.Fi.
+
+<Warning>
+Batch secure payment links — multiple payees in a single hosted link — are EVM-only. Tron Secure Payment links are single-recipient.
+</Warning>
+
+For the canonical chain × currency table and feature-support matrix, see [Supported Chains and Currencies](/resources/supported-chains-and-currencies).
 
 ## Supported currencies
 

--- a/api-features/webhooks-events.mdx
+++ b/api-features/webhooks-events.mdx
@@ -9,31 +9,20 @@ Webhooks provide real-time notifications when payment and request events occur, 
 
 ## Event Categories
 
-<CardGroup cols={2}>
-  <Card title="Payment Events" icon="credit-card">
-    **Core events:** confirmed, partial, failed, refunded
+The Request Network webhook system emits **12 event types** across four categories:
 
-    Immediate notification when payments are processed or fail
-  </Card>
+| Category | Events |
+| --- | --- |
+| **Payment** (core) | `payment.confirmed`, `payment.partial`, `payment.failed`, `payment.refunded` |
+| **Payment** (Client ID-scoped) | `payment.confirmed.client_id`, `payment.partial.client_id` |
+| **Payment** (Checkout-scoped) | `payment.confirmed.checkout`, `payment.partial.checkout` |
+| **Processing** (crypto-to-fiat) | `payment.processing` (with `subStatus`) |
+| **Request** | `request.recurring` |
+| **Compliance / Bank** | `compliance.updated`, `payment_detail.updated` |
 
-  <Card title="Processing Events" icon="spinner">
-    **Crypto-to-fiat:** payment.processing with detailed subStatus
+The `.client_id` and `.checkout` variants are emitted in addition to the base `.confirmed` / `.partial` events when the request was created via a Client ID or as a checkout / secure payment, respectively. They include extra metadata (`clientId`, `origin`).
 
-    Track multi-step fiat conversion progress
-  </Card>
-
-  <Card title="Request Events" icon="file-invoice">
-    **Recurring:** request.recurring
-
-    Automatic subscription renewal generation
-  </Card>
-
-  <Card title="Compliance Events" icon="shield-check">
-    **KYC & verification:** compliance.updated, payment_detail.updated
-
-    User verification and bank account status changes
-  </Card>
-</CardGroup>
+For full payload schemas and headers, see the [Webhooks reference](/api-reference/webhooks).
 
 ## How It Works
 

--- a/api-reference/secure-payments.mdx
+++ b/api-reference/secure-payments.mdx
@@ -5,11 +5,16 @@ description: "Generate secure payment URLs, retrieve payment metadata, and get e
 
 ## Endpoints
 
-- `POST /v2/secure-payments` — Create a secure payment
+- `POST /v2/secure-payments` — Create a secure payment (incoming, single or batch on EVM; single only on Tron)
+- `POST /v2/secure-payments/payouts` — Create a hosted secure payout link (outgoing payment to a recipient)
 - `GET /v2/secure-payments` — Lookup by request ID
 - `GET /v2/secure-payments/:token` — Get payment metadata
 - `GET /v2/secure-payments/:token/pay` — Get payment calldata
 - `POST /v2/secure-payments/:token/intent` — Record crosschain payment intent
+
+<Warning>
+Batch incoming and batch payouts are EVM-only. Tron requests with multiple `requests[]` items return a 400 with `Batch payments are not supported for TRON networks. Please submit individual payment requests.`
+</Warning>
 
 ## Authentication
 
@@ -91,6 +96,98 @@ curl -X POST "https://api.request.network/v2/secure-payments" \
 ### Error responses
 
 - `400`: invalid body or unsupported secure payment configuration
+- `401`: unauthorized
+- `429`: rate limited
+
+---
+
+## POST /v2/secure-payments/payouts
+
+Create a hosted **secure payout link** — an outgoing single-recipient payment URL the payer (you) opens to sign and broadcast the transaction. Useful for sending payments to contractors, vendors, or any external recipient when you want a hosted UI instead of executing calldata yourself.
+
+### Request fields
+
+<ParamField body="recipient" type="string" required>
+Recipient wallet address. EVM `0x...` or Tron `T...` format.
+</ParamField>
+
+<ParamField body="creatorWalletAddress" type="string" required>
+Wallet that created the payout (typically the payer wallet).
+</ParamField>
+
+<ParamField body="network" type="string" required>
+Destination network. Values: `mainnet`, `arbitrum-one`, `optimism`, `base`, `matic`, `bsc`, `tron`, `sepolia`.
+</ParamField>
+
+<ParamField body="currency" type="string" required>
+Payment currency in `<symbol>-<network>` form, e.g. `USDC-base`, `USDT-tron`, `FAU-sepolia`.
+</ParamField>
+
+<ParamField body="amount" type="string" required>
+Human-readable amount (e.g., `"100"`).
+</ParamField>
+
+<ParamField body="reference" type="string">
+Optional merchant reference (max 255 chars).
+</ParamField>
+
+<ParamField body="recipientIdentifier" type="string">
+Optional recipient identifier (max 255 chars).
+</ParamField>
+
+<ParamField body="feePercentage" type="string">
+Optional fee percentage from `0` to `100`.
+</ParamField>
+
+<ParamField body="feeAddress" type="string">
+Optional fee recipient address. Required when `feePercentage` is set.
+</ParamField>
+
+<RequestExample>
+```bash cURL (EVM payout)
+curl -X POST "https://api.request.network/v2/secure-payments/payouts" \
+  -H "x-api-key: YOUR_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "recipient": "0x6923831ACf5c327260D7ac7C9DfF5b1c3cB3C7D7",
+    "creatorWalletAddress": "0x2e2E5C79F571ef1658d4C2d3684a1FE97DD30570",
+    "network": "base",
+    "currency": "USDC-base",
+    "amount": "250",
+    "reference": "INVOICE-2026-042"
+  }'
+```
+
+```bash cURL (Tron payout)
+curl -X POST "https://api.request.network/v2/secure-payments/payouts" \
+  -H "x-api-key: YOUR_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "recipient": "TJRabPrwbZy45sbavfcjinPJC18kjpRTv8",
+    "creatorWalletAddress": "TKb9mFPjUgCbrQpenCm4Z3T7ELNrLWurfm",
+    "network": "tron",
+    "currency": "USDT-tron",
+    "amount": "250",
+    "reference": "INVOICE-2026-042"
+  }'
+```
+</RequestExample>
+
+<ResponseExample>
+```json 201 Created
+{
+  "requestIds": [
+    "01e273ecc29d4b526df3a0f1f05ffc59372af8752c2b678096e49ac270416a7cdb"
+  ],
+  "securePaymentUrl": "https://pay.request.network/?token=01PAYOUT123ABCDEF456",
+  "token": "01PAYOUT123ABCDEF456"
+}
+```
+</ResponseExample>
+
+### Error responses
+
+- `400`: invalid body, unsupported network/currency, or batch attempt on Tron
 - `401`: unauthorized
 - `429`: rate limited
 
@@ -228,6 +325,8 @@ Retrieve executable transaction calldata for the secure payment. For crosschain 
 
 <Info>
 The `:token` in the URL path is the secure payment token (a ULID identifier). The `token` query parameter is the source currency symbol (`USDC` or `USDT`) for crosschain route selection. These are different values.
+
+For **Tron** secure payments, do not pass `chain` or `token` query parameters — the calldata is generated for the Tron network directly. Tron payments are single-recipient and same-chain only.
 </Info>
 
 ### Path parameters
@@ -243,7 +342,7 @@ Payer wallet address. Used for approval and balance checks. Optional for Tron pa
 </ParamField>
 
 <ParamField query="chain" type="string">
-Source chain for crosschain payments. Values: `BASE`, `OPTIMISM`, `ARBITRUM`, `ETHEREUM`. Must be provided together with the `token` query parameter.
+Source chain for crosschain payments. Values: `BASE`, `OPTIMISM`, `ARBITRUM`, `ETHEREUM`, `POLYGON`, `BNB`. Must be provided together with the `token` query parameter. Crosschain swap-to-pay is EVM-source only.
 </ParamField>
 
 <ParamField query="token" type="string">

--- a/api-reference/wallet-authentication.mdx
+++ b/api-reference/wallet-authentication.mdx
@@ -12,9 +12,9 @@ This is the authentication method used by the [Request Dashboard](https://dashbo
 ## Supported Wallets
 
 - **EVM wallets** — MetaMask, WalletConnect, Coinbase Wallet, and any wallet supporting `personal_sign`
-- **Tron wallets** — TronLink (addresses starting with `T...`)
+- **Tron wallets** — TronLink, Guarda, Trust, WalletConnect-Tron (addresses starting with `T...`)
 
-The API auto-detects the wallet type from the address format.
+The API auto-detects the wallet type from the address format. Both EVM and Tron wallets are first-class authentication methods for the Dashboard and the auth API.
 
 ## Challenge/Verify Flow
 

--- a/api-reference/webhooks.mdx
+++ b/api-reference/webhooks.mdx
@@ -29,7 +29,7 @@ ngrok http 3000
 See [Payload Examples](#payload-examples) below for detailed webhook structures.
 </Info>
 
-### Payment Events
+### Payment Events (core)
 
 | Event | Description | Context | Primary Use |
 |-------|-------------|---------|-------------|
@@ -37,6 +37,24 @@ See [Payload Examples](#payload-examples) below for detailed webhook structures.
 | `payment.partial` | Partial payment received for request | Installments, partial orders | Update balance, allow additional payments |
 | `payment.failed` | Payment execution failed | Recurring payments, cross-chain transfers | Notify failure, retry logic, pause subscriptions |
 | `payment.refunded` | Payment has been refunded to payer | Cross-chain payment failures, refund scenarios | Update order status, notify customer |
+
+### Payment Events (Client ID-scoped)
+
+Emitted **in addition to** the core events when the originating request was created with a Client ID. Payload includes extra `clientId` and `origin` fields.
+
+| Event | Description |
+|-------|-------------|
+| `payment.confirmed.client_id` | Same as `payment.confirmed`, scoped to a Client ID |
+| `payment.partial.client_id` | Same as `payment.partial`, scoped to a Client ID |
+
+### Payment Events (Checkout / Secure Payment-scoped)
+
+Emitted **in addition to** the core events when the request was created via a Secure Payment / checkout flow.
+
+| Event | Description |
+|-------|-------------|
+| `payment.confirmed.checkout` | Same as `payment.confirmed`, originating from a Secure Payment link |
+| `payment.partial.checkout` | Same as `payment.partial`, originating from a Secure Payment link |
 
 ### Processing Events
 

--- a/release-notes/index.mdx
+++ b/release-notes/index.mdx
@@ -3,13 +3,9 @@ title: "Release Notes"
 description: "Stay up to date with the latest updates and improvements to Request Network products"
 ---
 
-<Warning>
-**AI-Generated Content** – This page was generated with AI assistance and may contain inaccuracies. While likely close to accurate, please verify critical details with the [stable documentation](https://docs.request.network) or [contact support](https://github.com/orgs/RequestNetwork/discussions).
-</Warning>
-
 # Release Notes
 
-Stay informed about the latest features, improvements, and bug fixes across all Request Network products. Our release notes provide detailed information about what's new and what's changed in each version.
+Stay informed about the latest features, improvements, and bug fixes across Request Network products. Our release notes provide detailed information about what's new and what's changed in each version.
 
 ## Product Release Notes
 

--- a/release-notes/request-api.mdx
+++ b/release-notes/request-api.mdx
@@ -1,145 +1,78 @@
 ---
 title: "Request API Release Notes"
-description: "Track updates, new features, and changes to the Request Network API"
+description: "Track recent updates and changes to the Request Network API"
 ---
 
-<Warning>
-**AI-Generated Content** – This page was generated with AI assistance and may contain inaccuracies. While likely close to accurate, please verify critical details with the [stable documentation](https://docs.request.network) or [contact support](https://github.com/orgs/RequestNetwork/discussions).
-</Warning>
+This page tracks notable changes to the Request Network v2 API. For the canonical changelog, see commit history in the [request-api repository](https://github.com/RequestNetwork/request-api).
 
-# Request API Release Notes
+## Recent updates
 
-This page documents all updates to the Request Network API, including new features, improvements, bug fixes, and breaking changes.
+<Update label="2026-Q2" description="Tron gas fee transparency">
 
-## Version 2.1.0 - Current
+### Improvements
 
-<Update label="v2.1.0" description="Released September 2025">
-
-### 🎉 New Features
-
-- **Enhanced Payment Status Tracking**: New webhook events for granular payment status updates
-- **Bulk Request Creation**: Create multiple payment requests in a single API call
-- **Advanced Filtering**: Extended query parameters for request listing endpoints
-- **Payment Intent Support**: Integration with Stripe Payment Intents for card payments
-
-### 🚀 Improvements
-
-- **Performance**: 40% faster response times for request creation
-- **Rate Limiting**: Increased rate limits for authenticated requests (1000/minute → 2000/minute)
-- **Error Messages**: More descriptive error responses with actionable suggestions
-- **Documentation**: Interactive API explorer with live examples
-
-### 🐛 Bug Fixes
-
-- Fixed timestamp formatting inconsistencies in webhook payloads
-- Resolved issue with currency conversion precision for small amounts
-- Fixed pagination edge case in request listing endpoint
-- Corrected decimal handling for Japanese Yen transactions
-
-### ⚠️ Breaking Changes
-
-None in this release.
+- **Tron gas fees** exposed in payment breakdowns. The `fees` array now includes Tron network gas costs (energy/bandwidth converted to TRX-equivalent USD) so payers and accountants can reconcile total spend across EVM and Tron payments uniformly.
 
 </Update>
 
-## Version 2.0.5
+<Update label="2026-Q1" description="Tron-first payouts and secure payment links">
 
-<Update label="v2.0.5" description="Released August 2025">
+### New Features
 
-### 🚀 Improvements
-
-- **Security**: Enhanced API key validation and rotation capabilities
-- **Monitoring**: Improved request tracing for better debugging
-- **Webhooks**: Retry mechanism with exponential backoff for failed deliveries
-
-### 🐛 Bug Fixes
-
-- Fixed rare concurrency issue in payment processing
-- Resolved webhook delivery order for high-volume scenarios
-- Corrected timezone handling in request expiration dates
+- **Secure payout links** — `POST /v2/secure-payments/payouts` returns a hosted URL the payer opens to send a single-recipient payment. Works on EVM and Tron. Pairs with the new `payout` flag on secure payments to distinguish incoming/outgoing flows when listing.
+- **Secure payment filtering** — `GET /v2/secure-payments` accepts filters to scope listings by request ID, payout vs incoming, and creation timestamp.
+- **Secure payments without bound destinations** — Client IDs without a bound `payeeDestinationId` can still create secure payments by supplying `requests[].destinationId` inline.
 
 </Update>
 
-## Version 2.0.0 - Major Release
+<Update label="2026-Q1" description="Tron network support">
 
-<Update label="v2.0.0" description="Released June 2025">
+### New Features
 
-### 🎉 New Features
+- **Tron** is a first-class destination network. Wallet sign-in via TronLink/Guarda/Trust/WalletConnect-Tron, USDT and USDC TRC-20 destinations, single-recipient payments, single-recipient payouts. Network ID `tron`, chain ID `728126428`.
+- **Network fee estimation for Tron** — readiness checks return whether the payer's wallet has enough TRX, energy, and bandwidth to broadcast the transaction.
+- **Max-allowance approval pattern** for Tron USDT (which does not allow approve-from-non-zero, similar to mainnet USDT).
 
-- **Multi-chain Support**: Native support for Ethereum, Polygon, Arbitrum, and more
-- **Payment Methods**: Credit card payments via Stripe integration
-- **Request Templates**: Reusable templates for recurring payment scenarios
-- **Advanced Webhooks**: Configurable event filtering and custom headers
+### Limitations
 
-### 🚀 Improvements
-
-- **RESTful Design**: Complete API redesign following REST principles
-- **OpenAPI Specification**: Comprehensive API documentation with interactive examples
-- **SDK Support**: Official SDKs for JavaScript, Python, and PHP
-- **Performance**: 10x improvement in request processing speed
-
-### ⚠️ Breaking Changes
-
-<Warning>
-This is a major version upgrade with significant breaking changes. Please review the migration guide carefully.
-</Warning>
-
-- **Endpoint Structure**: All endpoints have been restructured
-- **Authentication**: New API key format and authentication method
-- **Response Format**: Standardized response structure across all endpoints
-- **Field Names**: Several field names have been updated for consistency
-
-**Migration Resources:**
-- [Support Channel](https://request.network/discord) for migration assistance
+- **Batch payments are EVM-only.** Tron requests with multiple `requests[]` entries return a 400 with `Batch payments are not supported for TRON networks.`. Submit single-recipient payments instead.
 
 </Update>
 
-## API Versioning
+<Update label="2026-Q1" description="Payment amount accounting">
 
-### Current Version Support
+### Improvements
 
-- **v2.1.x**: Current stable version with full support
-- **v2.0.x**: Maintenance mode, security updates only
-- **v1.x**: **Deprecated** - End of life: December 2025
+- **Paid / received / excess amount fields** on the Payment model and webhook payloads. `totalAmountPaid` reflects the cumulative amount across multiple inbound transactions; the API now also returns `excessAmount` when a payer overpays.
 
-### Version Headers
+</Update>
 
-Always specify the API version in your requests:
+<Update label="2026-Q1" description="Calldata endpoint">
 
-```bash
-curl -H "API-Version: 2.1" \
-     -H "Authorization: Bearer YOUR_API_KEY" \
-     https://api.request.network/requests
-```
+### New Features
 
-### Breaking Change Policy
+- **`POST /v2/secure-payments/{token}/calldata`** generates executable transaction calldata for a secure payment after the payer has selected a chain/token. Replaces previous payment-intent flow for the calldata path.
 
-<Info>
-We follow semantic versioning and provide advance notice for breaking changes:
+</Update>
 
-- **Major versions** (2.0.0): May include breaking changes
-- **Minor versions** (2.1.0): New features, backward compatible
-- **Patch versions** (2.1.1): Bug fixes, backward compatible
-</Info>
+## Endpoint coverage today
 
-## Upcoming Features
+The v2 API exposes endpoints across these resource groups (see [Endpoints (V2)](/api-reference/endpoints-overview) for the OpenAPI-driven reference):
 
-### Q4 2025 Roadmap
+- **Requests** (`/v2/request`) — create, query, update, get calldata
+- **Payments** (`/v2/payments`) — search and reconcile
+- **Payouts** (`/v2/payouts`, `/v2/payouts/batch`, `/v2/payouts/recurring`) — single, batch (EVM-only), recurring
+- **Secure Payments** (`/v2/secure-payments`, `/v2/secure-payments/payouts`) — incoming and outgoing hosted links
+- **Currencies** (`/v2/currencies`) — supported tokens and conversion routes
+- **Commerce Payments** (`/v2/commerce-payments`) — authorize/capture/void/refund (preview)
+- **Payer** (`/v2/payer`) — crypto-to-fiat KYC and bank account flows
+- **Journey** (`/v2/journey`) — multi-hop payment tracing
+- **Client IDs** (`/v2/client-ids`) — see also auth API at `/v1/client-ids`
 
-- **GraphQL API**: Alternative query interface for complex data retrieval
-- **Batch Operations**: Bulk operations for high-volume use cases
-- **Advanced Analytics**: Detailed payment and request analytics
-- **Mobile SDKs**: Native iOS and Android SDK support
+For client ID, webhook, and payee destination management, see the [Auth API](https://auth.request.network/open-api).
 
-<Tip>
-Follow our [GitHub repository](https://github.com/RequestNetwork/request-api) to track development progress and provide feedback on upcoming features.
-</Tip>
+## Getting help
 
-## Getting Help
-
-If you have questions about any release or need migration assistance:
-
-- 📚 [API Documentation](/api-reference/authentication)
+- 📚 [API Reference](/api-reference/authentication)
 - 💬 [Discord Community](https://request.network/discord)
-- 📧 [Support Email](mailto:support@request.network)
-- 🐛 [Bug Reports](https://github.com/RequestNetwork/request-api/issues)
+- 🐛 [GitHub issues](https://github.com/RequestNetwork/request-api/issues)

--- a/resources/lifecycle-of-a-request.mdx
+++ b/resources/lifecycle-of-a-request.mdx
@@ -14,7 +14,7 @@ description: "The typical lifecycle of a request is as follows:"
 - The request is persisted in IPFS.
 - The IPFS Content-addressable ID (CID) is stored in a smart contract on Gnosis chain
 <Info>
-Requests are *created* by storing their CIDs on Gnosis, but this doesn't mean *payment* must occur on Gnosis. *Payment* can occur on any of the supported chains including EVM-compatible chains, Tron, or NEAR.
+Requests are *created* by storing their CIDs on Gnosis, but this doesn't mean *payment* must occur on Gnosis. *Payment* can occur on any of the supported chains — EVM-compatible chains and Tron.
 </Info>
 
 ## Update a request

--- a/resources/supported-chains-and-currencies.mdx
+++ b/resources/supported-chains-and-currencies.mdx
@@ -5,40 +5,72 @@ description: "Supported chains and currency coverage across Request Network API 
 
 ## Request Network API Supported Chains and Currencies
 
-Overall, Request Network API supports 500+ currencies across EVM-compatible chains and select non-EVM support (Tron).
+Request Network supports payment destinations on **8 networks** — 7 EVM chains and **Tron**. EVM and Tron are co-equal first-class networks for sign-in, payment destinations, payment links, and single payouts. The one current asymmetry: **batch payments (incoming or outgoing) are EVM-only** — the API rejects Tron batch requests.
 
-## ERC20, Native, and Conversion Payments Supported Chains
+## Supported networks
 
-EVM chains supported for core payment flows include:
+### Mainnet
 
-**Mainnet:**
-- Ethereum
-- Arbitrum One
-- OP Mainnet
-- Base
-- Polygon
-- BSC
-- Avalanche
-- Fantom
-- Gnosis
-- Mantle
-- zkSync Era
+| Network | Chain ID | Network ID | USDC | USDT | Notes |
+| --- | --- | --- | --- | --- | --- |
+| Ethereum | `1` | `mainnet` | ✓ | ✓ | |
+| Arbitrum One | `42161` | `arbitrum-one` | ✓ | ✓ | Also supports USDT0 |
+| Optimism | `10` | `optimism` | ✓ | ✓ | |
+| Base | `8453` | `base` | ✓ | ✓ | |
+| Polygon | `137` | `matic` | ✓ | ✓ | |
+| BNB Smart Chain | `56` | `bsc` | ✓ | ✓ | |
+| **Tron** | `728126428` | `tron` | ✓ | ✓ | TRC-20 tokens, `T...` addresses |
 
-**Testnet:**
-- Sepolia
+### Testnet
 
-For non-EVM support, Request Network API also supports Tron for USDT TRC-20 payments.
+| Network | Chain ID | Network ID | Tokens |
+| --- | --- | --- | --- |
+| Sepolia | `11155111` | `sepolia` | FAU, USDC, USDT |
+
+For canonical token addresses on each chain, see [TOKENS_PER_CHAIN](https://github.com/RequestNetwork/request-api/blob/main/src/constants/chains.ts) in the Request API repository.
+
+## Feature support per chain
+
+| Feature | EVM (7 chains) | Tron |
+| --- | --- | --- |
+| Wallet sign-in (Dashboard) | ✓ | ✓ |
+| Payment destinations (ERC-7828) | ✓ | ✓ |
+| Single incoming payments | ✓ | ✓ |
+| **Batch incoming payments** | ✓ | ✗ |
+| Single outgoing payouts | ✓ | ✓ |
+| **Batch outgoing payouts** | ✓ | ✗ |
+| Conversion payments (fiat-denominated) | ✓ | ✓ |
+| Cross-chain swap-to-pay (Li.Fi) | ✓ | ✓ |
+| Recurring payments | ✓ | ✓ |
+
+<Warning>
+Batch payments (one transaction paying multiple recipients, or one signed batch payout) are supported on EVM only. Submitting a batch with Tron payees returns a 400 with: `Batch payments are not supported for TRON networks. Please submit individual payment requests.`
+</Warning>
+
+## Tron specifics
+
+<Card title="Tron" icon="bolt">
+- **Mainnet only** — no Tron testnet support
+- **Native token:** TRX (used for energy/bandwidth fees)
+- **Stablecoins:** USDT (`TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t`), USDC (`TEkxiTehnzSmSe2XqrBj4w32RUN966rdz8`)
+- **Address format:** Base58, prefix `T`
+- **Wallets:** TronLink, Guarda, Trust, WalletConnect-Tron
+</Card>
+
+<Info>
+Tron wallet addresses are not interchangeable with EVM addresses. The API uses ERC-7828 `humanReadableInteropAddress` to disambiguate — Tron destinations resolve under the `eip155:728126428` namespace.
+</Info>
 
 ## ERC20 and Native Payments Supported Currencies
 
-For ERC20 and native payments, Request Network API supports 500+ tokens.
+For ERC20 and native payments, Request Network exposes a broader catalog of 500+ tokens (the Request Network Token List). The destinations and secure payment flows above use the curated subset on the canonical 8 networks.
 
 <Card title="Request Network Token List" href="/resources/token-list#token-list-structure" icon="list">
 Access the full token catalog with token IDs, symbols, and network mapping.
 </Card>
 
 <Info>
-The token list is a superset and may include tokens on chains outside your current payment flow. Cross-reference token entries with supported chains.
+The token list is a superset and may include tokens on chains outside the destination flow. For payment destinations and secure payment links, use the 8 networks listed above.
 </Info>
 
 ## Conversion Payments Supported Currencies
@@ -57,20 +89,6 @@ For Conversion Payments, supported **payment currencies** include:
 - USDT
 - DAI
 - FAU (Sepolia)
-
-## Tron Supported Network and Currency
-
-<Card title="Tron" icon="bolt">
-- **Availability:** Mainnet only
-- **Native Token:** TRX
-- **Supported Token:** USDT (TRC-20)
-- **Network ID:** `tron`
-- **Best For:** High-volume USDT transfers with low fees
-</Card>
-
-<Warning>
-Tron uses TRC-20 (not ERC-20). Wallet addresses use the `T...` format. The `wallet` parameter is optional for Tron payments — the API uses a fallback address when omitted.
-</Warning>
 
 To fetch supported payment currencies for an invoice currency:
 
@@ -122,11 +140,12 @@ Typical fields include:
 "USDC-mainnet"
 "USDC-base"
 "USDT-arbitrum-one"
-"DAI-optimism"
+"USDT0-arbitrum-one"
 ```
 
-```javascript Tron example
+```javascript Tron examples
 "USDT-tron"
+"USDC-tron"
 ```
 
 ```javascript Fiat invoice currency examples
@@ -145,7 +164,7 @@ curl -X GET 'https://api.request.network/v2/currencies' \
 ```
 
 ```bash Filter by network and symbol
-curl -X GET 'https://api.request.network/v2/currencies?network=base&symbol=USDC&firstOnly=true' \
+curl -X GET 'https://api.request.network/v2/currencies?network=tron&symbol=USDT&firstOnly=true' \
   -H 'x-api-key: YOUR_API_KEY'
 ```
 

--- a/resources/token-list.mdx
+++ b/resources/token-list.mdx
@@ -52,6 +52,21 @@ Each token in the list contains the following information:
 }
 ```
 
+Tron tokens use the same shape — `network: "tron"`, `chainId: 728126428`, `type: "TRC20"`, and base58 addresses (`T...`):
+
+```json
+{
+  "id": "USDT-tron",
+  "name": "Tether USD",
+  "symbol": "USDT",
+  "decimals": 6,
+  "address": "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t",
+  "network": "tron",
+  "type": "TRC20",
+  "chainId": 728126428
+}
+```
+
 | Field | Description |
 |-------|-------------|
 | `id` | Unique identifier, typically `SYMBOL-network` (e.g., `USDC-mainnet`) |
@@ -59,7 +74,7 @@ Each token in the list contains the following information:
 | `symbol` | Token symbol |
 | `decimals` | Number of decimal places |
 | `address` | Token contract address |
-| `network` | Network name (e.g., `mainnet`, `matic`, `bsc`, `tron`) |
+| `network` | Network name. Supported destination networks: `mainnet`, `arbitrum-one`, `optimism`, `base`, `matic`, `bsc`, `tron`, `sepolia` |
 | `type` | Currency type (e.g., `ERC20`, `ETH`, `ISO4217`) |
 | `hash` | For ERC20 tokens, same as `address`. For native tokens, a calculated hash. |
 | `chainId` | Chain ID of the network |


### PR DESCRIPTION
Bring existing API and resource pages in line with the current product:
- Tron is co-equal with EVM for single payments/payouts; called out explicitly
  on payee-destinations, payouts, secure-payments, wallet-auth, supported
  chains, token-list, and lifecycle pages.
- Batch (incoming and outgoing) is EVM-only; admonition added to
  batch-payments, payouts, secure-payments, and the supported-chains feature
  matrix, with the exact API error string for searchability.
- Webhook event list synced with the auth API's OutgoingWebhookEvent enum
  (12 events) — added .client_id and .checkout variants alongside the core
  4 payment events.
- Secure Payments reference: documented POST /v2/secure-payments/payouts,
  expanded crosschain chain enum (BASE/OPTIMISM/ARBITRUM/ETHEREUM/POLYGON/BNB),
  noted Tron-specific calldata path.
- Client ID schema: added operatorWalletAddress, defaultPreApprovalExpiry,
  defaultAuthorizationExpiry; called out Dashboard as the recommended path.
- Release notes rewritten to reflect actual recent shipments (Tron support,
  secure payouts, gas transparency, calldata endpoint); dropped v1 fiction.
- Stripped remaining EasyInvoice references from batch-payments and
  crypto-to-fiat-payments.