### PR TITLE
docs(secure-payments): document redirectUrl + redirectLabel

### DIFF
--- a/api-reference/secure-payments.mdx
+++ b/api-reference/secure-payments.mdx
@@ -62,6 +62,14 @@ Optional merchant reference for reconciliation (max 255 chars).
 Optional payer identifier (max 255 chars).
 </ParamField>
 
+<ParamField body="redirectUrl" type="string">
+Optional `http(s)` URL the payer is redirected to after a successful payment. Only safe URLs are accepted: scheme must be `http` or `https`, and the value must not contain HTML/script payload characters (`<`, `>`, `"`, `'`, ` `` `, whitespace). The URL is rendered as a button on the success screen — the payer clicks it to return to your site (no auto-redirect).
+</ParamField>
+
+<ParamField body="redirectLabel" type="string">
+Optional button label for the redirect (1–255 chars). Defaults to **"Go Back and Close"** when omitted. Cannot include HTML control characters (`<`, `>`, `&`, `"`, `'`, `` ` ``). **Cannot be set without `redirectUrl`** — the API rejects with 400 `redirectLabel cannot be provided without redirectUrl`.
+</ParamField>
+
 <RequestExample>
 ```bash cURL
 curl -X POST "https://api.request.network/v2/secure-payments" \
@@ -76,7 +84,9 @@ curl -X POST "https://api.request.network/v2/secure-payments" \
     ],
     "feePercentage": "2.5",
     "feeAddress": "0x6923831ACf5c327260D7ac7C9DfF5b1c3cB3C7D7",
-    "reference": "ORDER-2024-001"
+    "reference": "ORDER-2024-001",
+    "redirectUrl": "https://merchant.example.com/order/2024-001/thank-you",
+    "redirectLabel": "Back to merchant"
   }'
 ```
 </RequestExample>
@@ -143,6 +153,14 @@ Optional fee percentage from `0` to `100`.
 Optional fee recipient address. Required when `feePercentage` is set.
 </ParamField>
 
+<ParamField body="redirectUrl" type="string">
+Optional `http(s)` URL rendered as a button on the success screen for the signer to return to your app. Same validation rules as on `POST /v2/secure-payments` — see [above](#post-v2secure-payments).
+</ParamField>
+
+<ParamField body="redirectLabel" type="string">
+Optional button label (1–255 chars). Defaults to **"Go Back and Close"**. Cannot be set without `redirectUrl`.
+</ParamField>
+
 <RequestExample>
 ```bash cURL (EVM payout)
 curl -X POST "https://api.request.network/v2/secure-payments/payouts" \
@@ -154,7 +172,8 @@ curl -X POST "https://api.request.network/v2/secure-payments/payouts" \
     "network": "base",
     "currency": "USDC-base",
     "amount": "250",
-    "reference": "INVOICE-2026-042"
+    "reference": "INVOICE-2026-042",
+    "redirectUrl": "https://merchant.example.com/payouts/done"
   }'
 ```
 

--- a/tools/secure-payments.mdx
+++ b/tools/secure-payments.mdx
@@ -49,7 +49,7 @@ The Secure Payment page is intentionally separated from the merchant frontend so
   </Step>
 
   <Step title="Confirm">
-    The success screen shows the source and destination transaction hashes, with explorer links per chain. For cross-chain payments, a Li.Fi badge is displayed.
+    The success screen shows the source and destination transaction hashes, with explorer links per chain. For cross-chain payments, a Li.Fi badge is displayed. If you set a `redirectUrl` when creating the payment link, an extra button appears at the bottom of the screen — defaulting to **"Go Back and Close"**, or whatever you set as `redirectLabel` — that takes the payer back to your site.
 
     <Frame>
       <img src="/images/secure-payments/payment-success.webp" alt="Payment success screen" />

--- a/use-cases/programmatic-payment-links.mdx
+++ b/use-cases/programmatic-payment-links.mdx
@@ -109,6 +109,34 @@ curl -X POST "https://api.request.network/v2/secure-payments" \
 
 The response includes `securePaymentUrl` — share it with the customer. They open it on `pay.request.network`, connect a wallet, and pay.
 
+## Send the customer back to your site after payment
+
+Pass `redirectUrl` (and optionally `redirectLabel`) when creating the payment link. After a successful payment, the success screen renders a button that opens your URL — the payer clicks it to return to your site. There is no auto-redirect; the button is an explicit user action.
+
+```typescript
+await fetch("https://api.request.network/v2/secure-payments", {
+  method: "POST",
+  headers: {
+    "Content-Type": "application/json",
+    "x-client-id": process.env.RN_CLIENT_ID!,
+  },
+  body: JSON.stringify({
+    requests: [{ destinationId: process.env.MERCHANT_DESTINATION!, amount: "100" }],
+    reference: order.id,
+    redirectUrl: `https://yourshop.com/orders/${order.id}/thank-you`,
+    redirectLabel: "Back to your order",
+  }),
+});
+```
+
+**Validation rules:**
+- `redirectUrl` must be `http(s)`. Other schemes (`javascript:`, `data:`, etc.) and HTML/script payload characters are rejected with `400 redirectUrl must be a safe http(s) URL with no script/HTML payload`.
+- `redirectLabel` is 1–255 chars and rejects HTML control characters (`<`, `>`, `&`, `"`, `'`, `` ` ``).
+- `redirectLabel` cannot be set without `redirectUrl` — the API rejects with `400 redirectLabel cannot be provided without redirectUrl`.
+- If you don't pass `redirectLabel`, the button reads **"Go Back and Close"**.
+
+The same fields are accepted on `POST /v2/secure-payments/payouts` for hosted payout links.
+
 ## EVM and Tron destinations side-by-side
 
 Tron is a drop-in replacement for any EVM destination as long as you submit a single recipient per call. The shape is identical; only the `destinationId` and addresses change format.


### PR DESCRIPTION
The Request API now accepts an optional redirectUrl (and matching
redirectLabel) on POST /v2/secure-payments and POST /v2/secure-payments/
payouts. After a successful payment, the secure payment app renders a
button on the success screen that takes the payer back to the URL —
explicit user action, not an auto-redirect.

Documented across three pages so the API surface, payer-side UI, and
integration story all line up:

- api-reference/secure-payments.mdx — added redirectUrl + redirectLabel
  ParamFields on both POST endpoints, with the exact validation rules:
  http(s) only, no HTML/script payload chars; redirectLabel is 1–255
  chars and rejected without a redirectUrl.
- tools/secure-payments.mdx — Confirm step now mentions the back-to-site
  button, default copy ("Go Back and Close"), and the redirectLabel
  override.
- use-cases/programmatic-payment-links.mdx — added a "Send the customer
  back to your site after payment" section with a TS snippet and the
  full validation/error-string list, plus a note that the same fields
  apply to /payouts.