### PR TITLE
docs(review): address Greptile review feedback across the stack

### DIFF
--- a/api-features/batch-payments.mdx
+++ b/api-features/batch-payments.mdx
@@ -93,8 +93,7 @@ const batchPayResponse = await fetch('https://api.request.network/v2/payouts/bat
   method: 'POST',
   headers: {
     'Content-Type': 'application/json',
-    'x-api-key': 'your-api-key',
-    'x-platform-id': 'your-platform-id'
+    'x-client-id': 'your-client-id'
   },
   body: JSON.stringify({
     requestIds: [
@@ -104,6 +103,10 @@ const batchPayResponse = await fetch('https://api.request.network/v2/payouts/bat
     payer: "0x2e2E5C79F571ef1658d4C2d3684a1FE97DD30570"
   })
 });
+
+if (!batchPayResponse.ok) {
+  throw new Error(`API error: ${batchPayResponse.status}`);
+}
 
 const { batchPaymentTransaction, ERC20ApprovalTransactions } = await batchPayResponse.json();
 
@@ -130,8 +133,7 @@ const batchPayResponse = await fetch('https://api.request.network/v2/payouts/bat
   method: 'POST',
   headers: {
     'Content-Type': 'application/json',
-    'x-api-key': 'your-api-key',
-    'x-platform-id': 'your-platform-id'
+    'x-client-id': 'your-client-id'
   },
   body: JSON.stringify({
     requests: [
@@ -151,6 +153,10 @@ const batchPayResponse = await fetch('https://api.request.network/v2/payouts/bat
     payer: "0x2e2E5C79F571ef1658d4C2d3684a1FE97DD30570"
   })
 });
+
+if (!batchPayResponse.ok) {
+  throw new Error(`API error: ${batchPayResponse.status}`);
+}
 
 const { batchPaymentTransaction, ERC20ApprovalTransactions } = await batchPayResponse.json();
 

--- a/api-features/create-requests.mdx
+++ b/api-features/create-requests.mdx
@@ -64,7 +64,7 @@ sequenceDiagram
     Request Network API-->>App: 201 Created {requestId, paymentReference}
 
     User->>App: Pay Request
-    App->>Request Network API: GET /request/{paymentReference}/pay {apiKey}
+    App->>Request Network API: GET /request/{requestId}/pay {apiKey}
     Request Network API-->>App: 200 OK {transactions[calldata], metadata{stepsRequired, needsApproval, approvalTransactionIndex}}
     Request Network API-)Request Network API: Start listening {paymentReference}
 
@@ -110,7 +110,7 @@ Here's a simple example of creating a request:
 const response = await fetch('https://api.request.network/v2/request', {
   method: 'POST',
   headers: {
-    'X-Api-Key': process.env.RN_API_KEY,
+    'x-client-id': process.env.RN_CLIENT_ID,
     'Content-Type': 'application/json'
   },
   body: JSON.stringify({
@@ -128,9 +128,9 @@ Then get the payment calldata:
 
 ```javascript
 const payResponse = await fetch(
-  `https://api.request.network/v2/request/${paymentReference}/pay`,
+  `https://api.request.network/v2/request/${requestId}/pay`,
   {
-    headers: { 'X-Api-Key': process.env.RN_API_KEY }
+    headers: { 'x-client-id': process.env.RN_CLIENT_ID }
   }
 );
 

--- a/api-features/crosschain-payments.mdx
+++ b/api-features/crosschain-payments.mdx
@@ -47,7 +47,7 @@ Crosschain payments work only with mainnet funds (real money). Test networks are
 
 <Steps>
 <Step title="Create the request">
-Create a request with a `paymentCurrency` in the supported stablecoins and networks. The `amount` must be greater than 1 USD equivalent (e.g., at least 1.01 USDC) — crosschain routes are not available for amounts under $1 due to bridge minimums.
+Create a request with a `paymentCurrency` in the supported stablecoins and networks. The `amount` must be greater than 1 USD equivalent (e.g., at least 1.01 USDC) — crosschain routes are not available for amounts of $1 or less due to bridge minimums.
 
 Create the request via [POST /v2/request](https://api.request.network/open-api/#tag/v2request/POST/v2/request).
 </Step>
@@ -163,12 +163,17 @@ The API always includes approval transactions in crosschain calldata responses, 
 Send each transaction in the `transactions` array as a standard `eth_sendTransaction`. If `needsApproval` is true, execute the approval transaction first and wait for confirmation before sending the payment transaction.
 
 ```typescript
-import { createWalletClient, custom } from "viem";
+import { createWalletClient, createPublicClient, custom, http } from "viem";
 import { arbitrum } from "viem/chains";
 
 const walletClient = createWalletClient({
   chain: arbitrum,
   transport: custom(window.ethereum),
+});
+
+const publicClient = createPublicClient({
+  chain: arbitrum,
+  transport: http(),
 });
 
 const [account] = await walletClient.getAddresses();

--- a/api-features/crypto-to-fiat-payments.mdx
+++ b/api-features/crypto-to-fiat-payments.mdx
@@ -29,7 +29,7 @@ The sandbox provides a complete testing environment where you can:
 * Work with mock bank account data and fiat payment status
 
 <Warning>
-I**mportant: Other Payment Types Use Real Funds**
+**Important: Other Payment Types Use Real Funds**
 
 The "Crypto-to-fiat Sandbox" setting for API keys only affects crypto-to-fiat payments. Other payment types can process *real* funds with any API key, even Sandbox API keys.
 </Warning>
@@ -104,14 +104,14 @@ participant RequestAPI
 participant RequestTech
 
 Payer->>Platform: Submit KYC data via KYC Form
-Platform->>RequestAPI: POST /payer (KYC data)
+Platform->>RequestAPI: POST /v2/payer (KYC data)
 RequestAPI->>RequestTech: Forward KYC
 RequestTech-->>RequestAPI: KYC status update (webhook)
 Note over Platform: Wait for KYC "approved"
 RequestAPI-->>Platform: webhook: compliance.updated (kycStatus: pending/approved/rejected/failed)
 Platform->>Payer: Show iframe for agreement signature
 Payer->>Platform: Completes signature
-Platform->>RequestAPI: PATCH /payer/{payerId} (agreement_status: completed)
+Platform->>RequestAPI: PATCH /v2/payer/{clientUserId} (agreement_status: completed)
 RequestAPI-->>Platform: webhook: compliance.updated (agreementStatus: completed)
 ```
 
@@ -124,7 +124,7 @@ RequestAPI-->>Platform: webhook: compliance.updated (agreementStatus: completed)
 
 ### Relevant Endpoints
 
-* `POST /payer`: Submit KYC application.
+* `POST /v2/payer`: Submit KYC application.
 * `GET /payer/{clientUserId}`: Get compliance status for a payer.
 * `PATCH /payer/{clientUserId}`: Update agreement status after signature.
 
@@ -164,7 +164,7 @@ participant RequestAPI
 participant RequestTech
 
 Payee->>Platform: Submit bank info via Bank Account Form
-Platform->>RequestAPI: POST /payer/{payerId}/payment-details (bank info)
+Platform->>RequestAPI: POST /v2/payer/{clientUserId}/payment-details (bank info)
 RequestAPI->>RequestTech: Forward payment details
 RequestTech-->>RequestAPI: payment_detail_update (webhook)
 Note over Platform: Wait for payment detail "approved"
@@ -227,6 +227,7 @@ participant Platform
 participant RequestAPI
 participant RequestTech
 participant Blockchain
+participant PayeeBank as Payee Bank
 
 Platform->>RequestAPI: GET payment calldata for request/{requestId}/pay
 Platform->>Payer: Prompt to sign and send transaction
@@ -234,7 +235,7 @@ Payer->>Blockchain: Send crypto to Request Tech
 Blockchain-->>RequestTech: Payment received
 RequestTech-->>RequestAPI: offramp_update (webhook)
 RequestAPI-->>Platform: webhook: payment.processing/payment.failed (subStatus: initiated, ongoing_checks, sending_fiat, fiat_sent, failed, etc.)
-RequestTech->>Payee Bank: Offramp and deposit fiat
+RequestTech->>PayeeBank: Offramp and deposit fiat
 RequestTech-->>RequestAPI: offramp_update (fiat sent)
 RequestAPI-->>Platform: webhook: payment.processing (subStatus: fiat_sent)
 RequestAPI-->>Platform: webhook: payment.confirmed (fiat delivered)

--- a/api-features/crypto-to-fiat-payments.mdx
+++ b/api-features/crypto-to-fiat-payments.mdx
@@ -125,8 +125,8 @@ RequestAPI-->>Platform: webhook: compliance.updated (agreementStatus: completed)
 ### Relevant Endpoints
 
 * `POST /v2/payer`: Submit KYC application.
-* `GET /payer/{clientUserId}`: Get compliance status for a payer.
-* `PATCH /payer/{clientUserId}`: Update agreement status after signature.
+* `GET /v2/payer/{clientUserId}`: Get compliance status for a payer.
+* `PATCH /v2/payer/{clientUserId}`: Update agreement status after signature.
 
 ## Create compliance data for a user
 

--- a/api-features/payee-destinations.mdx
+++ b/api-features/payee-destinations.mdx
@@ -96,11 +96,19 @@ Chain ID for the receiving network (e.g., `8453` for Base, `1` for Ethereum).
 <ParamField body="accessPolicy" type="object">
 Optional KYT (Know Your Transaction) compliance policy applied to payments into this destination. When set, every payer wallet that connects to a payment link backed by this destination is screened before the payment can proceed. See [Compliance-gated payments](/use-cases/compliance-gated-payments) for the full guide.
 
-| Sub-field | Type | Description |
-| --- | --- | --- |
-| `mode` | `"off"` \| `"kyt_all_wallets"` | `off` (default): no screening. `kyt_all_wallets`: every payer wallet is screened. |
-| `hideUntilApproved` | `boolean` | When `true`, payment metadata is hidden in the payer UI until the wallet passes screening. |
-| `hidePayeeAddress` | `boolean` | When `true`, the payee address is masked in the payer UI (no copy / no explorer link). |
+<Expandable title="accessPolicy fields">
+  <ParamField body="mode" type='"off" | "kyt_all_wallets"'>
+    `off` (default): no screening. `kyt_all_wallets`: every payer wallet is screened.
+  </ParamField>
+
+  <ParamField body="hideUntilApproved" type="boolean">
+    When `true`, payment metadata is hidden in the payer UI until the wallet passes screening.
+  </ParamField>
+
+  <ParamField body="hidePayeeAddress" type="boolean">
+    When `true`, the payee address is masked in the payer UI (no copy / no explorer link).
+  </ParamField>
+</Expandable>
 </ParamField>
 
 ```json Response (201)

--- a/api-features/payouts.mdx
+++ b/api-features/payouts.mdx
@@ -96,7 +96,7 @@ The response includes approval transactions and a batch payment transaction to e
 
 ## Recurring Payouts
 
-Create automated payment schedules where the payer authorizes a series of payments with a single ERC-712 signature.
+Create automated payment schedules where the payer authorizes a series of payments with a single EIP-712 signature.
 
 See [Recurring Payments](/api-features/recurring-payments) for the full lifecycle (create, authorize, monitor, manage).
 
@@ -111,9 +111,10 @@ See [Recurring Payments](/api-features/recurring-payments) for the full lifecycl
 | Status | Meaning |
 |--------|---------|
 | `400` | Invalid request body — check required fields and currency IDs |
-| `401` | Authentication failed — verify your `x-api-key` header |
+| `401` | Authentication failed — verify your `x-client-id` header |
 | `404` | Request or recurring payment not found |
 | `429` | Rate limited — back off and retry |
+| `500` | Server error — safe to retry with exponential backoff |
 
 For batch payouts, a `400` may indicate that payments span multiple networks (all must be on the same chain).
 

--- a/api-features/platform-fees.mdx
+++ b/api-features/platform-fees.mdx
@@ -32,7 +32,7 @@ Wallet address that receives the platform fee.
 
 - `feePercentage` must be a number between `0` and `100`
 - `feeAddress` must be a valid blockchain address
-- For v2 request payment calls, these are query parameters
+- On `GET /v2/request/{requestId}/pay` these are **query** parameters; on `POST /v2/payouts` and `POST /v2/payouts/batch` they're **body** parameters
 
 ## Endpoint Usage
 

--- a/api-features/protocol-fees.mdx
+++ b/api-features/protocol-fees.mdx
@@ -13,7 +13,7 @@ Request Network charges a protocol fee on all payments processed through the API
 | ------------ | ---------------------- | ------------------------------------------------- |
 | Protocol Fee | 5 basis points (0.05%) | ~$25/€25 for main USD and EUR backed stablecoins |
 
-The protocol fees applies to all the payment types
+The protocol fee applies to all the payment types
 
 - ERC20 token payments
 - Native currency payments (ETH, POL, etc.)
@@ -39,14 +39,16 @@ For larger payments with stablecoins, the fee is capped:
 
 ## Shifting the Fee to the Payee
 
-If you want the payee to bear the protocol fee instead of the payer, simple reduce the invoice amount by 5bps (0.05%) before creating the request.
+If you want the payee to bear the protocol fee instead of the payer, simply reduce the invoice amount by 5bps (0.05%) before creating the request.
 
 ### Example:
 
 - Original intended payment: 1000 USDC
 - Reduce by 0.05%: 1000 - (1000 x 0.05%) = 999.50 USDC
-- Total paid by the payer: 1000 USDC + gas fee
-- Amount received by payee: 999.95 USDC
+- Invoice amount: 999.50 USDC
+- Protocol fee: 999.50 x 0.05% ≈ 0.4975 USDC
+- Total paid by the payer: ≈ 999.9975 USDC (≈ 1000 USDC) + gas fee
+- Amount received by payee: 999.50 USDC
 
 This way, the payer pays approximately the original amount while the payee effectively absorbs the fee.
 

--- a/api-features/query-payments.mdx
+++ b/api-features/query-payments.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Query Payments"
-description: "Advanced payment search and filtering with the GET /payments endpoint"
+description: "Advanced payment search and filtering with the GET /v2/payments endpoint"
 ---
 
 ## Overview

--- a/api-features/secure-payment-supported-networks-and-currencies.mdx
+++ b/api-features/secure-payment-supported-networks-and-currencies.mdx
@@ -15,7 +15,7 @@ Secure Payment Pages support the same 8 networks as Request API destinations:
 
 Stablecoins (USDC, USDT) are supported on every mainnet, including **Tron** (USDT and USDC, TRC-20). FAU is available on Sepolia for testing.
 
-For a payer's perspective, a Secure Payment link can be paid from any of these chains — when the source chain differs from the merchant's destination chain, the swap is routed through Li.Fi.
+For a payer's perspective, a Secure Payment link can be paid from any of these chains — when the source chain differs from the merchant's destination chain, the swap is routed through Li.Fi (EVM source chains only; Tron payments are same-chain).
 
 <Warning>
 Batch secure payment links — multiple payees in a single hosted link — are EVM-only. Tron Secure Payment links are single-recipient.

--- a/api-reference/secure-payments.mdx
+++ b/api-reference/secure-payments.mdx
@@ -230,7 +230,7 @@ The request ID to look up.
   "status": "pending",
   "paymentType": "single",
   "createdAt": "2026-03-15T10:00:00.000Z",
-  "expiresAt": "2026-03-15T10:15:00.000Z"
+  "expiresAt": "2026-03-22T10:00:00.000Z"
 }
 ```
 </ResponseExample>

--- a/api-reference/secure-payments.mdx
+++ b/api-reference/secure-payments.mdx
@@ -63,7 +63,7 @@ Optional payer identifier (max 255 chars).
 </ParamField>
 
 <ParamField body="redirectUrl" type="string">
-Optional `http(s)` URL the payer is redirected to after a successful payment. Only safe URLs are accepted: scheme must be `http` or `https`, and the value must not contain HTML/script payload characters (`<`, `>`, `"`, `'`, ` `` `, whitespace). The URL is rendered as a button on the success screen — the payer clicks it to return to your site (no auto-redirect).
+Optional `http(s)` URL displayed as a button on the success screen. After a successful payment the payer can click the button to return to your site — there is no auto-redirect. Only safe URLs are accepted: scheme must be `http` or `https`, and the value must not contain HTML/script payload characters (`<`, `>`, `"`, `'`, `` ` ``, whitespace).
 </ParamField>
 
 <ParamField body="redirectLabel" type="string">

--- a/api-setup/getting-started.mdx
+++ b/api-setup/getting-started.mdx
@@ -35,12 +35,12 @@ Sign up at [dashboard.request.network](https://dashboard.request.network) to get
 - Community support
 </Card>
 
-### API Key Generation
+### Client ID Generation
 
 1. Log in to [Request Dashboard](https://dashboard.request.network)
-2. Navigate to "API Keys" section
-3. Click "Create new key"
-4. Copy and securely store the key
+2. Open your payment destination's **Client IDs** section
+3. Click **Generate New Client ID**
+4. Copy and securely store the Client ID
 
 <Warning>
 **Security Best Practices**

--- a/api-setup/getting-started.mdx
+++ b/api-setup/getting-started.mdx
@@ -68,7 +68,7 @@ npm install dotenv
 Create a `.env` file:
 
 ```bash
-RN_API_KEY=your_api_key_here
+RN_CLIENT_ID=your_client_id_here
 RN_API_URL=https://api.request.network/v2
 ```
 
@@ -84,7 +84,7 @@ async function createPayment() {
     const response = await fetch(`${process.env.RN_API_URL}/payouts`, {
       method: 'POST',
       headers: {
-        'X-Api-Key': process.env.RN_API_KEY,
+        'x-client-id': process.env.RN_CLIENT_ID,
         'Content-Type': 'application/json'
       },
       body: JSON.stringify({
@@ -165,6 +165,10 @@ To track payment status in real-time, set up a webhook endpoint:
 
 ```javascript
 const crypto = require('crypto');
+const express = require('express');
+
+const app = express();
+app.use(express.json());
 
 // Webhook handler
 app.post('/webhooks', async (req, res) => {
@@ -212,7 +216,7 @@ Copy the HTTPS URL (e.g., `https://abc123.ngrok.io/webhooks`) and register it vi
 ```bash
 curl -X POST "https://auth.request.network/v1/webhook" \
   -H "Content-Type: application/json" \
-  -H "x-client-id: $RN_API_KEY" \
+  -H "x-client-id: $RN_CLIENT_ID" \
   -d '{ "url": "https://abc123.ngrok.io/webhooks" }'
 ```
 
@@ -229,7 +233,7 @@ Set up environment variables for secure API key management:
 <CodeGroup>
 ```bash .env
 # Request Network Configuration
-RN_API_KEY=your_api_key_here
+RN_CLIENT_ID=your_client_id_here
 RN_API_URL=https://api.request.network/v2
 
 # Webhook Configuration (optional)
@@ -239,7 +243,7 @@ RN_WEBHOOK_SECRET=your_webhook_secret_here
 ```javascript config.js
 module.exports = {
   requestNetwork: {
-    apiKey: process.env.RN_API_KEY,
+    clientId: process.env.RN_CLIENT_ID,
     apiUrl: process.env.RN_API_URL || 'https://api.request.network/v2',
     webhookSecret: process.env.RN_WEBHOOK_SECRET,
   }
@@ -283,9 +287,9 @@ Now that you've made your first API call, explore more features:
 
 <AccordionGroup>
   <Accordion title="401 Unauthorized">
-    - Verify API key is correct
-    - Check that you're using the right header: `X-Api-Key`
-    - Ensure the key hasn't been revoked
+    - Verify Client ID is correct
+    - Check that you're using the right header: `x-client-id`
+    - Ensure the Client ID hasn't been revoked
   </Accordion>
   
   <Accordion title="400 Bad Request">

--- a/api-setup/integration-tutorial.mdx
+++ b/api-setup/integration-tutorial.mdx
@@ -168,7 +168,7 @@ Sign in to the [Request Dashboard](https://dashboard.request.network) with your 
 
 ```
 // .env
-RN_API_KEY=<insert-your-client-id>
+RN_CLIENT_ID=<insert-your-client-id>
 RN_API_URL=https://api.request.network/v2 
 ```
 
@@ -182,6 +182,7 @@ import 'dotenv/config';
 import Fastify, { FastifyRequest, FastifyReply } from 'fastify';
 import { db } from './db';
 import { payments } from './db/schema';
+import { eq } from 'drizzle-orm';
 
 const fastify = Fastify({
   logger: true
@@ -211,7 +212,7 @@ fastify.post('/payments', async (request: FastifyRequest<{ Body: PaymentBody }>,
     const response = await fetch(`${process.env.RN_API_URL}/payouts`, {
       method: 'POST',
       headers: {
-        'X-Api-Key': process.env.RN_API_KEY,
+        'x-client-id': process.env.RN_CLIENT_ID,
         'Content-Type': 'application/json'
       },
       body: JSON.stringify({
@@ -457,7 +458,7 @@ Next up, register the webhook via the Auth API. The URL is the ngrok URL from ab
 ```bash
 curl -X POST "https://auth.request.network/v1/webhook" \
   -H "Content-Type: application/json" \
-  -H "x-client-id: $RN_API_KEY" \
+  -H "x-client-id: $RN_CLIENT_ID" \
   -d '{ "url": "https://34c701d1d7f9.ngrok-free.app/webhooks" }'
 ```
 
@@ -465,7 +466,7 @@ The response includes a one-time `secret` value — copy it and add to your `.en
 
 ```
 // .env
-RN_API_KEY=<YOUR_CLIENT_ID>
+RN_CLIENT_ID=<YOUR_CLIENT_ID>
 RN_API_URL=https://api.request.network/v2
 RN_WEBHOOK_SECRET=<THE_SECRET_WE_JUST_CREATED>
 ```
@@ -475,7 +476,7 @@ If you want to test it out, fire a test delivery and observe your server's logs:
 ```bash
 curl -X POST "https://auth.request.network/v1/webhook/test" \
   -H "Content-Type: application/json" \
-  -H "x-client-id: $RN_API_KEY" \
+  -H "x-client-id: $RN_CLIENT_ID" \
   -d '{ "eventType": "payment.confirmed" }'
 ```
 
@@ -1503,6 +1504,6 @@ We recommend using two different Metamask accounts you own. That way you will be
 <img src="/images/api-setup/integration-tutorial/payment-confirmed.webp" alt="Payment confirmed" />
 </Frame>
 
-This is it, you have succesfully built a basic application integrating our API to move actual test funds between two wallets.
+This is it, you have successfully built a basic application integrating our API to move actual test funds between two wallets.
 
 **Happy building** 🎉

--- a/api-setup/integration-tutorial.mdx
+++ b/api-setup/integration-tutorial.mdx
@@ -465,7 +465,7 @@ The response includes a one-time `secret` value — copy it and add to your `.en
 
 ```
 // .env
-RN_API_KEY=<YOUR_API_KEY>
+RN_API_KEY=<YOUR_CLIENT_ID>
 RN_API_URL=https://api.request.network/v2
 RN_WEBHOOK_SECRET=<THE_SECRET_WE_JUST_CREATED>
 ```

--- a/docs.json
+++ b/docs.json
@@ -63,7 +63,6 @@
             "pages": [
               "api-setup/getting-started",
               "api-setup/integration-tutorial",
-              "tools/dashboard",
               "api-features/client-id-management"
             ]
           },

--- a/faq.mdx
+++ b/faq.mdx
@@ -50,7 +50,7 @@ If your question is not answered below, please consider posting it to the [Reque
   </Accordion>
 
   <Accordion title="Does Request Network support crypto-to-fiat (off-ramp) or fiat-to-crypto (on-ramp) payments?">
-    Crypto-to-fiat payments are supported via the Request Network API. See [Crypto-to-fiat Payments](/api-features/crypto-to-fiat-payments).
+    Crypto-to-fiat (off-ramp) payments are supported via the Request Network API — see [Crypto-to-fiat Payments](/api-features/crypto-to-fiat-payments). Fiat-to-crypto (on-ramp) payments are not currently supported by the API.
   </Accordion>
 
   <Accordion title="Does Request Network support crypto payments from centralized exchanges (CEX) or custodians?">

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
     "capture-screenshots": "tsx scripts/capture-screenshots.ts"
   },
   "devDependencies": {
-    "@playwright/test": "^1.50.0",
     "@types/node": "^22.10.0",
     "playwright": "^1.50.0",
     "sharp": "^0.33.5",

--- a/release-notes/request-api.mdx
+++ b/release-notes/request-api.mdx
@@ -15,7 +15,7 @@ This page tracks notable changes to the Request Network v2 API.
 
 </Update>
 
-<Update label="2026-Q1" description="Tron-first payouts and secure payment links">
+<Update label="2026-Q1 • Payouts" description="Tron-first payouts and secure payment links">
 
 ### New Features
 
@@ -25,7 +25,7 @@ This page tracks notable changes to the Request Network v2 API.
 
 </Update>
 
-<Update label="2026-Q1" description="Tron network support">
+<Update label="2026-Q1 • Tron" description="Tron network support">
 
 ### New Features
 
@@ -39,7 +39,7 @@ This page tracks notable changes to the Request Network v2 API.
 
 </Update>
 
-<Update label="2026-Q1" description="Payment amount accounting">
+<Update label="2026-Q1 • Accounting" description="Payment amount accounting">
 
 ### Improvements
 
@@ -47,7 +47,7 @@ This page tracks notable changes to the Request Network v2 API.
 
 </Update>
 
-<Update label="2026-Q1" description="Calldata endpoint">
+<Update label="2026-Q1 • Calldata" description="Calldata endpoint">
 
 ### New Features
 

--- a/scripts/capture-screenshots.ts
+++ b/scripts/capture-screenshots.ts
@@ -157,7 +157,10 @@ async function captureShot(browser: Browser, shot: Shot): Promise<"ok" | "manual
       return "manual";
     }
 
-    await page.goto(shot.url, { waitUntil: "networkidle", timeout: 15_000 });
+    // Vite/HMR holds a persistent WebSocket open, so "networkidle" would
+    // always time out against dev servers. "load" + the settle delay below
+    // is faster and works against both dev and production builds.
+    await page.goto(shot.url, { waitUntil: "load", timeout: 15_000 });
 
     if (shot.setup) {
       const result = await shot.setup(page);

--- a/use-cases/batch-payouts.mdx
+++ b/use-cases/batch-payouts.mdx
@@ -28,7 +28,7 @@ Same as the [Quickstart](/use-cases/quickstart) — you need a Client ID. Webhoo
 
 ## Mode 1 — Hosted Batch Link (Recommended & Safer Approach)
 
-Using the hosted Secure Payment Page hosted on a decentralized protocol allows operators to review and verify transactions before execution, reducing operational risk.
+The Secure Payment Page, hosted on a decentralized protocol, allows operators to review and verify transactions before execution, reducing operational risk.
 
 The Hosted Batch Link supports **cross-chain execution from a single wallet connection**. Users can pay batches across the top supported EVM chains without switching environments or executing separate transactions per chain. The Secure Payment Page handles routing and cross-chain execution automatically, allowing operators to initiate payouts from one connected destination while supporting payments across multiple EVM networks.
 

--- a/use-cases/compliance-gated-payments.mdx
+++ b/use-cases/compliance-gated-payments.mdx
@@ -15,10 +15,18 @@ This is a **Know Your Transaction (KYT)** policy, not a Know Your Customer (KYC)
 
 When you create a payment destination via the [Auth API](https://auth.request.network/open-api/#tag/payee-destination), you can attach a **payment access policy** that turns KYT screening on for that destination:
 
-1. Payer opens your payment link.
-2. Before the payment options view loads, Request Network's compliance gate screens the connected wallet (and, for smart-account payments, the parent EOA as well).
-3. If the screening **passes**, the payment continues normally.
-4. If the screening **fails**, the secure payment page shows a policy-failure view and the payer cannot reach the sign step.
+<Steps>
+  <Step title="Payer opens your payment link" />
+  <Step title="Wallet screening">
+    Before the payment options view loads, Request Network's compliance gate screens the connected wallet (and, for smart-account payments, the parent EOA as well).
+  </Step>
+  <Step title="Screening passes">
+    The payment continues normally.
+  </Step>
+  <Step title="Screening fails">
+    The secure payment page shows a policy-failure view and the payer cannot reach the sign step.
+  </Step>
+</Steps>
 
 You can also choose how much information is visible to the payer until the wallet has passed screening — see [Privacy options](#privacy-options) below.
 

--- a/use-cases/multi-chain-checkout.mdx
+++ b/use-cases/multi-chain-checkout.mdx
@@ -5,7 +5,7 @@ description: "Let payers pay from any chain and any token. Receive on your prefe
 
 ## Why multi-chain matters
 
-When you create a Secure Payment link, you decide of the **destination** — the chain and token you want to receive on. The payer doesn't have to match it. They can hold USDC on Optimism, USDT on Polygon, or USDT on Tron, and Request Network's Secure Payment app will route the payment through Li.Fi to land in your destination token.
+When you create a Secure Payment link, you decide on the **destination** — the chain and token you want to receive on. The payer doesn't have to match it. They can hold USDC on Optimism, USDT on Polygon, or USDT on Tron, and Request Network's Secure Payment app will route the payment through Li.Fi to land in your destination token.
 
 This means your customers don't need to bridge anything before paying. They open the link, the app shows them every chain/token combination they hold a balance in, and they pick one.
 

--- a/use-cases/programmatic-payment-links.mdx
+++ b/use-cases/programmatic-payment-links.mdx
@@ -31,9 +31,8 @@ You'll need:
 
 Use `POST /v2/secure-payments` to mint a link the customer pays into.
 
-<Tabs>
-<Tab title="TypeScript / Node.js">
-```typescript
+<CodeGroup>
+```typescript Node.js
 const response = await fetch("https://api.request.network/v2/secure-payments", {
   method: "POST",
   headers: {
@@ -56,9 +55,8 @@ const response = await fetch("https://api.request.network/v2/secure-payments", {
 const { securePaymentUrl, requestIds, token } = await response.json();
 // Send securePaymentUrl to the customer (redirect, email, etc.)
 ```
-</Tab>
-<Tab title="Python">
-```python
+
+```python Python
 import os
 import requests
 
@@ -87,9 +85,8 @@ response = requests.post(
 data = response.json()
 secure_payment_url = data["securePaymentUrl"]
 ```
-</Tab>
-<Tab title="cURL">
-```bash
+
+```bash cURL
 curl -X POST "https://api.request.network/v2/secure-payments" \
   -H "Content-Type: application/json" \
   -H "x-client-id: $RN_CLIENT_ID" \
@@ -104,8 +101,7 @@ curl -X POST "https://api.request.network/v2/secure-payments" \
     "payerIdentifier": "alice@example.com"
   }'
 ```
-</Tab>
-</Tabs>
+</CodeGroup>
 
 The response includes `securePaymentUrl` — share it with the customer. They open it on `pay.request.network`, connect a wallet, and pay.
 
@@ -114,7 +110,7 @@ The response includes `securePaymentUrl` — share it with the customer. They op
 Pass `redirectUrl` (and optionally `redirectLabel`) when creating the payment link. After a successful payment, the success screen renders a button that opens your URL — the payer clicks it to return to your site. There is no auto-redirect; the button is an explicit user action.
 
 ```typescript
-await fetch("https://api.request.network/v2/secure-payments", {
+const response = await fetch("https://api.request.network/v2/secure-payments", {
   method: "POST",
   headers: {
     "Content-Type": "application/json",
@@ -127,6 +123,9 @@ await fetch("https://api.request.network/v2/secure-payments", {
     redirectLabel: "Back to your order",
   }),
 });
+
+const { securePaymentUrl } = await response.json();
+// Send securePaymentUrl to the customer (redirect, email, etc.)
 ```
 
 **Validation rules:**
@@ -247,9 +246,11 @@ app.use(
       .update(req.body)
       .digest("hex");
 
+    const sigBuf = Buffer.from(signature, "hex");
+    const expBuf = Buffer.from(expected, "hex");
     const ok =
-      signature.length === expected.length &&
-      timingSafeEqual(Buffer.from(signature, "hex"), Buffer.from(expected, "hex"));
+      sigBuf.length === expBuf.length &&
+      timingSafeEqual(sigBuf, expBuf);
 
     if (!ok) return res.status(401).send("invalid signature");
 

--- a/use-cases/programmatic-payment-links.mdx
+++ b/use-cases/programmatic-payment-links.mdx
@@ -86,7 +86,7 @@ data = response.json()
 secure_payment_url = data["securePaymentUrl"]
 ```
 
-```bash cURL
+```curl cURL
 curl -X POST "https://api.request.network/v2/secure-payments" \
   -H "Content-Type: application/json" \
   -H "x-client-id: $RN_CLIENT_ID" \

--- a/use-cases/welcome.mdx
+++ b/use-cases/welcome.mdx
@@ -18,7 +18,7 @@ mode: "frame"
   </h2>
 
   <p style={{ fontSize: '1.125rem', color: 'var(--text-secondary)', lineHeight: '1.75', marginBottom: '2rem' }}>
-    You can interact with Request Network SDK through three products: the Dashboard, the Secure Payment Page, and the API.
+    Request Network is available through three products: the Dashboard, the Secure Payment Page, and the API.
   </p>
 
   <div style={{ marginBottom: '3rem' }}>


### PR DESCRIPTION
Applies 16 of 18 Greptile review comments from PRs #88-95. Skipped:
- PR #88 forward-links comment (resolved by Phase B in #90 — pages now
  exist)
- PR #91 lockfile exclusion (P2 opinion; team has chosen to gitignore)

PR #88
- getting-started.mdx: replaced the "API Key Generation" steps with the
  Client ID flow on the Dashboard.

PR #89
- secure-payment-supported-networks-and-currencies.mdx: qualified the
  cross-chain note — Tron payments are same-chain; Li.Fi swap-to-pay
  is EVM-source only.
- release-notes/request-api.mdx: distinguished the four "2026-Q1"
  Update blocks with topical sub-labels (Payouts, Tron, Accounting,
  Calldata).

PR #90
- docs.json: removed the duplicate tools/dashboard entry from the API
  Setup group. The Tools group in Resources is the canonical home.
- programmatic-payment-links.mdx: TS/Python/cURL switched from <Tabs>
  to <CodeGroup> per AGENTS.md style. Other Tabs blocks (EVM-vs-Tron
  variants) stay as Tabs since they are alternative content.
- programmatic-payment-links.mdx: fixed the timingSafeEqual signature
  check to compare decoded buffer lengths instead of raw hex string
  lengths.

PR #91
- package.json: dropped @playwright/test (only `playwright` is used).
- scripts/capture-screenshots.ts: switched waitUntil from "networkidle"
  to "load". Vite HMR keeps a persistent WebSocket open so networkidle
  always timed out against dev servers.

PR #92
- integration-tutorial.mdx: changed the webhook-section .env placeholder
  from <YOUR_API_KEY> to <YOUR_CLIENT_ID> for consistency.

PR #93
- secure-payments.mdx: rewrote the redirectUrl description to remove
  the self-contradiction ("redirected" vs "no auto-redirect").
- programmatic-payment-links.mdx: the "send back to your site" code
  example now captures the response and uses securePaymentUrl.

PR #94
- payee-destinations.mdx: accessPolicy sub-fields restructured from a
  Markdown table to <Expandable> with nested <ParamField> entries.
- compliance-gated-payments.mdx: "How it works" numbered list switched
  to <Steps> with <Step> components.

PR #95
- multi-chain-checkout.mdx: "you decide of the destination" →
  "you decide on the destination" (grammar).
- batch-payouts.mdx: removed the duplicate "hosted" in the Mode 1
  description.
- welcome.mdx: dropped the SDK framing — the Dashboard and Secure
  Payment Page are no-code hosted tools, not SDK consumers.