### PR TITLE
docs(review): apply Tristan's two must-fix items from the final review

### DIFF
--- a/api-reference/wallet-authentication.mdx
+++ b/api-reference/wallet-authentication.mdx
@@ -32,7 +32,7 @@ The API auto-detects the wallet type from the address format. Both EVM and Tron 
     {
       "challengeId": "01HXEXAMPLE123",
       "nonce": "a1b2c3d4e5f6",
-      "message": "auth.request.network wants you to sign in with your Ethereum account:\n0x6923831ACf5c327260D7ac7C9DfF5b1c3cB3C7D7\n\nSign in to Request Network\n\nURI: https://auth.request.network\nVersion: 1\nChain ID: 1\nNonce: a1b2c3d4e5f6\nIssued At: 2026-03-15T10:00:00.000Z",
+      "message": "auth.request.network wants you to sign in with your Ethereum account:\n0x6923831ACf5c327260D7ac7C9DfF5b1c3cB3C7D7\n\nSign in to Request Network.\n\nURI: https://auth.request.network\nVersion: 1\nNonce: a1b2c3d4e5f6\nIssued At: 2026-03-15T10:00:00.000Z\nExpiration Time: 2026-03-15T10:05:00.000Z",
       "expiresAt": "2026-03-15T10:05:00.000Z"
     }
     ```

--- a/api-setup/getting-started.mdx
+++ b/api-setup/getting-started.mdx
@@ -38,9 +38,10 @@ Sign up at [dashboard.request.network](https://dashboard.request.network) to get
 ### Client ID Generation
 
 1. Log in to [Request Dashboard](https://dashboard.request.network)
-2. Open your payment destination's **Client IDs** section
-3. Click **Generate New Client ID**
-4. Copy and securely store the Client ID
+2. **Create a payment destination first** if you haven't — the Client IDs section is only available once a destination exists. From the Home page, click **Set up payment destination** and pick the chain + token you want to receive on.
+3. Open **Manage Destination → Client IDs**
+4. Click **Generate your first Client ID** (or **Generate New Client ID** if you already have one)
+5. Copy and securely store the Client ID
 
 <Warning>
 **Security Best Practices**


### PR DESCRIPTION
(1) api-reference/wallet-authentication.mdx — SIWE message example now
matches the actual server output from request-auth-api/auth.service.ts:
- "Sign in to Request Network" → "Sign in to Request Network." (period
  per the source string)
- Dropped the "Chain ID: 1" line (the server does not emit it)
- Added "Expiration Time: <iso>" line (the server emits it after Issued
  At; used the same value the docs already show for `expiresAt`)

(2) api-setup/getting-started.mdx — Client ID Generation steps
- Added a prerequisite step pointing users to create a payment
  destination first, because the Client IDs section is only visible
  once a destination exists.
- Empty-state button labelled "Generate your first Client ID" (the
  actual dashboard label for the first-Client-ID case, per
  ManageDestination/blocks/ClientIdsSection.tsx). "Generate New Client
  ID" is still mentioned as the post-first-creation label.