### PR TITLE
docs: add recommended Tron wallets to wallet authentication page

### DIFF
--- a/api-reference/wallet-authentication.mdx
+++ b/api-reference/wallet-authentication.mdx
@@ -18,7 +18,7 @@ The API auto-detects the wallet type from the address format. Both EVM and Tron 
 
 ### Recommended Tron wallets
 
-In order of recommendation, based on team testing:
+We rank these in order of recommendation, based on team testing:
 
 1. **Trust** browser extension
 2. **Trust** mobile app via WalletConnect (scan the QR)
@@ -26,9 +26,9 @@ In order of recommendation, based on team testing:
 4. **Guarda** browser extension
 5. **OKX** browser extension
 
-<Note>
+<Warning>
 MetaMask is not recommended for Tron — its Tron support is partial.
-</Note>
+</Warning>
 
 ## Challenge/Verify Flow
 

--- a/api-reference/wallet-authentication.mdx
+++ b/api-reference/wallet-authentication.mdx
@@ -12,9 +12,23 @@ This is the authentication method used by the [Request Dashboard](https://dashbo
 ## Supported Wallets
 
 - **EVM wallets** — MetaMask, WalletConnect, Coinbase Wallet, and any wallet supporting `personal_sign`
-- **Tron wallets** — TronLink, Guarda, Trust, WalletConnect-Tron (addresses starting with `T...`)
+- **Tron wallets** — addresses starting with `T...` (see [Recommended Tron wallets](#recommended-tron-wallets))
 
 The API auto-detects the wallet type from the address format. Both EVM and Tron wallets are first-class authentication methods for the Dashboard and the auth API.
+
+### Recommended Tron wallets
+
+In order of recommendation, based on team testing:
+
+1. **Trust** browser extension
+2. **Trust** mobile app via WalletConnect (scan the QR)
+3. **TronLink** browser extension
+4. **Guarda** browser extension
+5. **OKX** browser extension
+
+<Note>
+MetaMask is not recommended for Tron — its Tron support is partial.
+</Note>
 
 ## Challenge/Verify Flow
 


### PR DESCRIPTION
# Problem

The Tron wallets listed on the wallet authentication page are unordered and don't reflect the team's tested recommendation. Users have asked which wallet to use (most recently Blockscout in the Tron Telegram thread on 2026-05-13), and we don't currently flag that MetaMask's Tron support is partial.

# Proposed Solution

- Replace the inline Tron wallets list on `api-reference/wallet-authentication.mdx` with an ordered `### Recommended Tron wallets` subsection based on team testing: Trust (browser extension), Trust mobile via WalletConnect QR, TronLink, Guarda, OKX.
- Add a `<Note>` callout that MetaMask is not recommended for Tron because its Tron support is partial.

# Considerations

- Recommendation order is a current snapshot; happy to update as wallet support evolves.
- The EVM wallet list is unchanged — MetaMask remains correctly listed there.
- The new `### Recommended Tron wallets` subsection produces a stable anchor (`...wallet-authentication#recommended-tron-wallets`) that can be linked directly from Slack, Telegram, and other support replies.
