### PR TITLE
fix: REQ 159 docs stale paths

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -30,6 +30,20 @@
   "thumbnails": {
     "appearance": "dark"
   },
+  "redirects": [
+    {
+      "source": "/api-features/no-code-payment-links",
+      "destination": "/use-cases/no-code-payment-links"
+    },
+    {
+      "source": "/api-features/programmatic-payment-links",
+      "destination": "/use-cases/programmatic-payment-links"
+    },
+    {
+      "source": "/api-features/authentication",
+      "destination": "/api-reference/authentication"
+    }
+  ],
   "navigation": {
     "tabs": [
       {


### PR DESCRIPTION
### TL;DR

Added redirects for moved documentation pages to prevent broken links.

### What changed?

Three redirect rules were added to `docs.json`:

- `/api-features/no-code-payment-links` → `/use-cases/no-code-payment-links`
- `/api-features/programmatic-payment-links` → `/use-cases/programmatic-payment-links`
- `/api-features/authentication` → `/api-reference/authentication`

### How to test?

Navigate to any of the old URLs (e.g., `/api-features/no-code-payment-links`) and verify that you are automatically redirected to the corresponding new destination URL.

### Why make this change?

These pages were relocated from the `api-features` section to more appropriate sections (`use-cases` and `api-reference`). The redirects ensure that any existing links or bookmarks pointing to the old URLs continue to work without returning 404 errors.

### Linear Issue: 

#### https://linear.app/requestnetwork/issue/REQ-159/fix-stale-payment-link-and-auth-paths-redirects