### PR TITLE
docs: sync with stack (Safe, multicall, orchestrators, USDT0/KYT) + remove PII-as-reference

### DIFF
--- a/api-features/crypto-to-fiat-payments.mdx
+++ b/api-features/crypto-to-fiat-payments.mdx
@@ -71,8 +71,8 @@ This four-step approach is required due to current API limitations - more stream
 
 Many `/payer` endpoints in the Request Network API require a `clientUserId` as a path parameter. This value is an **arbitrary identifier** chosen by your platform to represent a user (the payer) in your own system.
 
-* **You control the format:** The `clientUserId` can be any unique string that makes sense for your application. It can be a UUID, email address, database ID, or anything unique per user on your platform.
-* **Common pattern:** Many integrations set `clientUserId` to the user's email address or an internal user ID.
+* **You control the format:** The `clientUserId` can be any unique string that makes sense for your application. It can be a UUID, a database ID, or anything unique per user on your platform.
+* **Common pattern:** Many integrations set `clientUserId` to an internal user ID from their own system.
 * **Why is this useful?** This approach allows you to integrate the Request Network API without having to change your existing user management logic. You simply pass your own identifier to the API, and all payer-related compliance, agreement, and payment detail records will be associated with that value.
 
 **Example usage:**

--- a/api-features/payouts.mdx
+++ b/api-features/payouts.mdx
@@ -7,10 +7,11 @@ description: "Initiate single, batch, and recurring payments directly via the AP
 
 Payouts let you initiate payments without a separate request creation step. The API creates the request and returns executable transaction calldata in a single call.
 
-**Three payout modes:**
+**Payout modes:**
 - **Single** — Pay one recipient
-- **Batch** — Pay multiple recipients in one transaction (same network)
+- **Batch** — Pay multiple recipients in one transaction (same network, EVM)
 - **Recurring** — Automated payment schedules with ERC20 permit signatures
+- **Multicall** — Combine multiple existing payout links into one bundle, including across chains and on Tron
 
 ## Single Payout
 
@@ -56,7 +57,7 @@ curl -X POST "https://api.request.network/v2/payouts" \
 **Optional fields:**
 - `reference` — Merchant reference for reconciliation
 - `feePercentage` and `feeAddress` — Platform fee configuration
-- `customerInfo` — Payer information (name, email, address)
+- `customerInfo` — optional structured metadata to attach to the request
 - `payer` — Payer wallet address (required for recurring)
 
 The response includes `requestId` and a `transactions` array with executable calldata.
@@ -66,7 +67,7 @@ The response includes `requestId` and a `transactions` array with executable cal
 Pay multiple recipients in a single blockchain transaction. All payments must be on the same network.
 
 <Warning>
-**EVM-only.** Batch payouts work on EVM chains. Tron batch payouts are not supported — the API rejects them with `Batch payments are not supported for TRON networks.` For Tron, submit individual `POST /v2/payouts` calls per recipient.
+**EVM-only.** Batch payouts work on EVM chains. Tron batch payouts are not supported — the API rejects them with `Batch payments are not supported for TRON networks. Please submit individual payment requests.` For Tron, submit individual `POST /v2/payouts` calls per recipient.
 </Warning>
 
 ```bash
@@ -93,6 +94,32 @@ curl -X POST "https://api.request.network/v2/payouts/batch" \
 ```
 
 The response includes approval transactions and a batch payment transaction to execute.
+
+## Multicall payouts
+
+Multicall payouts combine multiple **existing** outgoing payout links into a single hosted link the payer settles as one bundle. Unlike [batch payouts](#batch-payout) — which are same-network and EVM-only — multicall supports cross-chain routing and Tron.
+
+Create a multicall link from previously created secure-payout tokens:
+
+```bash
+curl -X POST "https://api.request.network/v2/secure-payments/multicall-payouts" \
+  -H "x-client-id: YOUR_CLIENT_ID" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "childTokens": ["01JZ4PC7EXAMPLECHILD000001", "01JZ4PC7EXAMPLECHILD000002"]
+  }'
+```
+
+The response returns a parent `token` and `securePaymentUrl`. Share the URL with whoever signs payouts; they review every recipient and settle the whole bundle in one flow.
+
+**Execution kinds:**
+- `evm_same_chain` — all recipients on one network and currency, settled as a single batch transaction.
+- `evm_cross_chain` — recipients span chains/currencies (or the payer pays from a different source); each leg is routed via Li.Fi.
+- `tron_batch` — all recipients on Tron, settled via the Tron batch contract.
+
+When you omit `requestedExecutionKind`, it is derived from the payer's source selection at payment time. The default cap is 150 children (20 for cross-chain).
+
+See [Multicall payouts in the Secure Payments reference](/api-reference/secure-payments#post-v2secure-paymentsmulticall-payouts) for the full request/response schema, eligibility rules, and validation errors.
 
 ## Recurring Payouts
 

--- a/api-features/payouts.mdx
+++ b/api-features/payouts.mdx
@@ -103,7 +103,7 @@ Create a multicall link from previously created secure-payout tokens:
 
 ```bash
 curl -X POST "https://api.request.network/v2/secure-payments/multicall-payouts" \
-  -H "x-client-id: YOUR_CLIENT_ID" \
+  -H "x-api-key: YOUR_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
     "childTokens": ["01JZ4PC7EXAMPLECHILD000001", "01JZ4PC7EXAMPLECHILD000002"]

--- a/api-features/query-payments.mdx
+++ b/api-features/query-payments.mdx
@@ -141,11 +141,7 @@ Pagination offset.
         "requestId": "01e273ecc29d4b526df3a0f1f05ffc59372af8752c2b678096e49ac270416a7cdb",
         "paymentReference": "0xb3581f0b0f74cc61",
         "hasBeenPaid": true,
-        "customerInfo": {
-          "firstName": "John",
-          "lastName": "Doe",
-          "email": "john@example.com"
-        },
+        "customerInfo": null,
         "reference": "ORDER-2024-001234"
       }
     }

--- a/api-features/safe-multisig-payments.mdx
+++ b/api-features/safe-multisig-payments.mdx
@@ -1,0 +1,145 @@
+---
+title: "Safe Multisig Payments"
+description: "Pay a secure payment from an existing Gnosis Safe multisig: request Safe-ready calldata, execute on your Safe, and track settlement via the intent endpoint."
+---
+
+## Overview
+
+When the wallet paying a secure payment is an existing [Gnosis Safe](https://safe.global/) multisig, the payment cannot be broadcast in a single signature — it has to be proposed on the Safe, signed by the required owners, and then executed. Request Network supports this flow directly: you ask the calldata endpoint for **Safe-ready** transactions, execute them on your Safe off-platform, and then hand the resulting Safe transaction hash back to the API so it can track settlement.
+
+This is distinct from the [smart-account path](/api-features/secure-payment-pages#smart-account-payments) on the hosted secure payment page, which derives its own ERC-4337 account automatically. Use the flow on this page when **your own payer wallet is a Safe** and you execute the transaction yourself.
+
+<Info>
+Safe multisig payments are **EVM-only**. They are not supported on Tron — requesting Safe calldata for a Tron network returns a 400.
+</Info>
+
+## How it works
+
+<Steps>
+  <Step title="Request Safe-ready calldata">
+    Call `GET /v2/secure-payments/:token/pay` with `isSafe=true` and `wallet` set to the **Safe address**. The API returns calldata sized and priced for a Safe (it includes the required approval transactions and skips the EOA native-gas balance check).
+
+    ```bash
+    curl -X GET "https://api.request.network/v2/secure-payments/01ABC123DEF456GHI789JKL/pay?wallet=0xSAFE_ADDRESS&isSafe=true" \
+      -H "x-client-id: YOUR_CLIENT_ID"
+    ```
+
+    <Warning>
+    `isSafe=true` is mutually exclusive with `eoaWallet`, and `wallet` is required. The `wallet` value must be the Safe address that will execute the payment.
+    </Warning>
+  </Step>
+
+  <Step title="Propose and execute on your Safe">
+    Propose the returned transactions to your Safe, collect the required owner signatures, and execute. This happens entirely on your side using your Safe tooling — Request Network does not custody keys or co-sign.
+  </Step>
+
+  <Step title="Record the Safe transaction">
+    Once the Safe transaction is created, tell the API to start tracking it by calling `POST /v2/secure-payments/:token/intent` with `safeTxHash` (instead of `txHash`).
+
+    ```bash
+    curl -X POST "https://api.request.network/v2/secure-payments/01ABC123DEF456GHI789JKL/intent" \
+      -H "x-client-id: YOUR_CLIENT_ID" \
+      -H "Content-Type: application/json" \
+      -d '{
+        "safeTxHash": "0xSAFE_TX_HASH",
+        "chain": "POLYGON",
+        "token": "USDC",
+        "safePaymentDeadline": 1749760800
+      }'
+    ```
+
+    Exactly one of `txHash` or `safeTxHash` must be provided. `safePaymentDeadline` is optional (Unix seconds) and can only be sent alongside `safeTxHash`.
+  </Step>
+
+  <Step title="Poll for settlement">
+    While the Safe transaction is pending execution, `GET /v2/secure-payments/:token` returns **HTTP 423 (Locked)** with the message `Secure payment is in progress` and a `requestStatuses[]` array carrying `safeTxHash`, `chainId`, and `safePaymentDeadline`. Request Network resolves the Safe transaction in the background: once executed it records the real on-chain transaction hash and confirms the payment; if it fails or the deadline passes, the payment is marked failed.
+  </Step>
+</Steps>
+
+## Request fields
+
+### `GET /v2/secure-payments/:token/pay`
+
+<ParamField query="wallet" type="string" required>
+The Safe address that will execute the payment. Used for balance and approval calculation.
+</ParamField>
+
+<ParamField query="isSafe" type="boolean">
+Set to `true` to prepare calldata for a Gnosis Safe multisig payer. Mutually exclusive with `eoaWallet`; `wallet` must be set to the Safe address.
+</ParamField>
+
+<ParamField query="chain" type="string">
+Source chain for cross-chain payments. Values: `BASE`, `OPTIMISM`, `ARBITRUM`, `ETHEREUM`, `POLYGON`, `BNB`. Provide together with `token`.
+</ParamField>
+
+<ParamField query="token" type="string">
+Source currency for cross-chain payments. Values: `USDC`, `USDT`. Provide together with `chain`.
+</ParamField>
+
+### `POST /v2/secure-payments/:token/intent`
+
+<ParamField body="safeTxHash" type="string">
+The Safe transaction hash to track. Provide **either** `safeTxHash` (Safe multisig flow) **or** `txHash` (already-broadcast on-chain hash) — exactly one.
+</ParamField>
+
+<ParamField body="safePaymentDeadline" type="number">
+Unix timestamp (seconds) — the hard on-chain execution deadline for the Safe + cross-chain route. Only valid alongside `safeTxHash`; the API stops tracking once this passes.
+</ParamField>
+
+<ParamField body="chain" type="string" required>
+Source chain. Values: `BASE`, `OPTIMISM`, `ARBITRUM`, `ETHEREUM`, `POLYGON`, `BNB`.
+</ParamField>
+
+<ParamField body="token" type="string" required>
+Source token. Values: `USDC`, `USDT`.
+</ParamField>
+
+<ParamField body="payerAddress" type="string">
+Optional address of the wallet making the payment. Echoed back on the response.
+</ParamField>
+
+<ResponseExample>
+```json 200 OK (intent recorded)
+{
+  "intentId": "01HXEXAMPLE123",
+  "paymentReference": "0xb3581f0b0f74cc61",
+  "safeTxHash": "0xSAFE_TX_HASH",
+  "safePaymentDeadline": 1749760800,
+  "isListening": true
+}
+```
+</ResponseExample>
+
+## Status while a Safe payment is in progress
+
+<ResponseExample>
+```json 423 Locked
+{
+  "message": "Secure payment is in progress",
+  "status": "pending",
+  "requestStatuses": [
+    {
+      "requestId": "01e273ecc29d4b526df3a0f1f05ffc59372af8752c2b678096e49ac270416a7cdb",
+      "hasBeenPaid": false,
+      "safeTxHash": "0xSAFE_TX_HASH",
+      "chainId": 137,
+      "safePaymentDeadline": 1749760800
+    }
+  ]
+}
+```
+</ResponseExample>
+
+Treat `423` as "keep polling" — the Safe transaction has been recorded but not yet executed on-chain. Once Request Network detects execution, the request flips to paid (and `GET /v2/secure-payments/:token` returns the completed state); a `payment.confirmed` webhook fires as usual.
+
+## Related
+
+<CardGroup cols={2}>
+  <Card title="Secure Payments API Reference" href="/api-reference/secure-payments" icon="book">
+    Full request/response schemas for the secure payment endpoints.
+  </Card>
+
+  <Card title="Smart account payments" href="/api-features/secure-payment-pages#smart-account-payments" icon="wand-magic-sparkles">
+    The automatic ERC-4337 path on the hosted page (for EOA payers).
+  </Card>
+</CardGroup>

--- a/api-features/secure-payment-pages.mdx
+++ b/api-features/secure-payment-pages.mdx
@@ -68,25 +68,38 @@ Secure payment pages support crosschain payments. When a payer connects their wa
 
 **Supported crosschain currencies:** USDC, USDT
 
-**Supported crosschain chains:** Ethereum, Arbitrum, Base, OP Mainnet, Polygon
+**Supported crosschain chains:** Ethereum, Arbitrum, Base, OP Mainnet, Polygon, BNB Chain
 
 See [Crosschain Payments](/api-features/crosschain-payments) for details on crosschain routing via LiFi.
 
 ## Smart Account Payments
 
-The secure payment page supports gas-sponsored payments via [Safe](https://safe.global/) smart accounts (ERC-4337), bundled and sponsored through [Pimlico](https://pimlico.io/). When available, payers can use a smart account to execute payments without paying gas fees.
+For supported EVM payments, the secure payment page can execute through an ERC-4337 [Safe](https://safe.global/) smart account derived automatically from the payer's connected wallet, bundled through [Pimlico](https://pimlico.io/). The whole payment — approval, funding, and settlement — runs as a single UserOperation.
 
 **How it works:**
 
-1. The payer approves a spending cap from their EOA wallet to the smart account
-2. The smart account batches the `transferFrom` (EOA to smart account) and the payment transaction into a single UserOperation
-3. Gas is sponsored via Pimlico's paymaster — the payer pays zero gas
+1. The payer authorizes the token spend. For tokens that support [EIP-2612 `permit`](#gasless-token-approvals-eip-2612) (such as USDC), this is an off-chain signature with no separate approval transaction; for other tokens (such as USDT) it is a one-time on-chain approval.
+2. The smart account batches the `permit`/approval, the funding transfer from the payer's wallet, and the payment transaction into a single UserOperation.
+3. The bundler submits the UserOperation and the page surfaces the resulting on-chain transaction hash on the success screen.
 
-**Supported chains for smart account payments:** Ethereum, Base, Arbitrum, Optimism, Polygon, BSC, and Sepolia (testnet).
+**Supported chains for smart account payments:** Ethereum, Base, Arbitrum, Optimism, Polygon, and BNB Chain (plus Sepolia testnet). Native-currency payments and Tron payments do not use the smart-account path.
 
 <Info>
-Smart account payments are a client-side feature of the hosted secure payment page. There is no separate API for smart accounts — the same `GET /v2/secure-payments/:token/pay` endpoint provides the transaction calldata.
+Smart account payments are an automatic client-side behavior of the hosted secure payment page. There is no API field to enable them — the same `GET /v2/secure-payments/:token/pay` endpoint provides the transaction calldata, and the page decides whether to route through a smart account. To pay from an existing **Gnosis Safe multisig** programmatically, see [Safe multisig payments](/api-features/safe-multisig-payments).
 </Info>
+
+### Gasless token approvals (EIP-2612)
+
+ERC-20 payments normally need a separate `approve()` transaction before the transfer, which costs the payer extra gas. On the smart-account path, the secure payment page checks each token at runtime for [EIP-2612](https://eips.ethereum.org/EIPS/eip-2612) `permit` support:
+
+- **Permit-enabled tokens (e.g. USDC, EURC)** — the payer signs an off-chain `permit` instead of sending an approval transaction. No approval gas is required, and the approval gas line item is hidden in the payer's cost breakdown.
+- **Non-permit tokens (e.g. USDT, DAI)** — the page falls back to a standard one-time on-chain `approve()`, which costs native gas as usual.
+
+The approval is a one-time authorization that stays in effect until revoked (the page exposes a revoke control), and it applies to both single payments and [multicall payouts](/api-features/payouts#multicall-payouts). Gasless approvals are available on the same chains as smart-account payments listed above.
+
+<Note>
+Whether a token is gasless is determined per token at payment time by probing the token contract, not from a fixed list — any EIP-2612-compliant token gets the gasless signature path. USDC/EURC and USDT/DAI are cited here only as common examples.
+</Note>
 
 ## Status outcomes
 

--- a/api-features/secure-payment-supported-networks-and-currencies.mdx
+++ b/api-features/secure-payment-supported-networks-and-currencies.mdx
@@ -13,7 +13,7 @@ Secure Payment Pages support the same 8 networks as Request API destinations:
 | Non-EVM | **Tron** |
 | Testnet | Sepolia |
 
-Stablecoins (USDC, USDT) are supported on every mainnet, including **Tron** (USDT and USDC, TRC-20). FAU is available on Sepolia for testing.
+Stablecoins (USDC, USDT) are supported on every mainnet, including **Tron** (USDT and USDC, TRC-20). **USDT0** is additionally available as a payment currency (an alias of USDT) on Arbitrum One, Optimism, and Polygon. FAU is available on Sepolia for testing.
 
 For a payer's perspective, a Secure Payment link can be paid from any of these chains — when the source chain differs from the merchant's destination chain, the swap is routed through Li.Fi (EVM source chains only; Tron payments are same-chain).
 

--- a/api-reference/secure-payments.mdx
+++ b/api-reference/secure-payments.mdx
@@ -11,20 +11,24 @@ description: "Generate secure payment URLs, retrieve payment metadata, and get e
 - `GET /v2/secure-payments/:token` — Get payment metadata
 - `GET /v2/secure-payments/:token/pay` — Get payment calldata
 - `POST /v2/secure-payments/:token/intent` — Record crosschain payment intent
+- `POST /v2/secure-payments/multicall-payouts` — Combine multiple existing payout links into one multicall link
+- `GET /v2/secure-payments/multicall-payouts/:token` — Get multicall payout details (operator/session auth)
 
 <Warning>
-Batch incoming and batch payouts are EVM-only. Tron requests with multiple `requests[]` items return a 400 with `Batch payments are not supported for TRON networks. Please submit individual payment requests.`
+Batch incoming and batch payouts are EVM-only. Tron requests with multiple `requests[]` items return a 400 with `Batch payments are not supported for TRON networks`.
 </Warning>
 
 ## Authentication
 
 | Endpoint | Supported auth |
 |----------|---------------|
-| `POST /v2/secure-payments` | `x-api-key`, `x-client-id` + Origin, or session |
+| `POST /v2/secure-payments` | `x-api-key`, `x-client-id` + Origin, session, or orchestrator pair |
 | `GET /v2/secure-payments` | Session only |
-| `GET /v2/secure-payments/:token` | `x-api-key` or `x-client-id` |
-| `GET /v2/secure-payments/:token/pay` | `x-api-key` or `x-client-id` |
-| `POST /v2/secure-payments/:token/intent` | `x-api-key` or `x-client-id` |
+| `GET /v2/secure-payments/:token` | `x-client-id` (+ Origin) |
+| `GET /v2/secure-payments/:token/pay` | `x-client-id` (+ Origin) |
+| `POST /v2/secure-payments/:token/intent` | `x-client-id` (+ Origin) |
+| `POST /v2/secure-payments/multicall-payouts` | `x-api-key`, `x-client-id` + Origin, session, or orchestrator pair |
+| `GET /v2/secure-payments/multicall-payouts/:token` | Session only |
 
 ---
 
@@ -334,6 +338,7 @@ curl -X GET "https://api.request.network/v2/secure-payments/01ABC123DEF456GHI789
 - `403`: token expired or not payable
 - `404`: token not found
 - `409`: secure payment already completed
+- `423`: a Safe multisig payment is in progress — keep polling (see [Safe multisig payments](/api-features/safe-multisig-payments))
 - `429`: rate limited
 
 ---
@@ -366,6 +371,14 @@ Source chain for crosschain payments. Values: `BASE`, `OPTIMISM`, `ARBITRUM`, `E
 
 <ParamField query="token" type="string">
 Source currency for crosschain payments. Values: `USDC`, `USDT`. Must be provided together with `chain`.
+</ParamField>
+
+<ParamField query="isSafe" type="boolean">
+Set to `true` when the payer wallet is a Gnosis Safe multisig. Returns Safe-ready calldata; `wallet` must be the Safe address and `eoaWallet` must not be set. See [Safe multisig payments](/api-features/safe-multisig-payments).
+</ParamField>
+
+<ParamField query="eoaWallet" type="string">
+Externally-owned account address used to fund a smart-account payment. Mutually exclusive with `isSafe`.
 </ParamField>
 
 <RequestExample>
@@ -469,16 +482,28 @@ Secure payment token.
 
 ### Request fields
 
-<ParamField body="txHash" type="string" required>
-The source-chain transaction hash (66 characters: `0x` + 64 hex chars).
+<ParamField body="txHash" type="string">
+The source-chain transaction hash (66 characters: `0x` + 64 hex chars). Provide **either** `txHash` **or** `safeTxHash` — exactly one.
+</ParamField>
+
+<ParamField body="safeTxHash" type="string">
+A Gnosis Safe transaction hash to track instead of an already-broadcast `txHash`. Used for [Safe multisig payments](/api-features/safe-multisig-payments). Provide exactly one of `txHash` or `safeTxHash`.
+</ParamField>
+
+<ParamField body="safePaymentDeadline" type="number">
+Unix timestamp (seconds) — the hard on-chain execution deadline for the Safe route. Only valid alongside `safeTxHash`.
 </ParamField>
 
 <ParamField body="chain" type="string" required>
-The source chain. Values: `BASE`, `OPTIMISM`, `ARBITRUM`, `ETHEREUM`.
+The source chain. Values: `BASE`, `OPTIMISM`, `ARBITRUM`, `ETHEREUM`, `POLYGON`, `BNB`.
 </ParamField>
 
 <ParamField body="token" type="string" required>
 The source token. Values: `USDC`, `USDT`.
+</ParamField>
+
+<ParamField body="payerAddress" type="string">
+Optional address of the wallet making the payment. Echoed back on the response.
 </ParamField>
 
 <RequestExample>
@@ -511,4 +536,149 @@ curl -X POST "https://api.request.network/v2/secure-payments/01ABC123DEF456GHI78
 - `403`: token expired or not payable
 - `404`: token not found
 - `409`: secure payment already completed
+- `429`: rate limited
+
+---
+
+## POST /v2/secure-payments/multicall-payouts
+
+Combine multiple existing **outgoing payout** secure-payment links into a single multicall link the payer settles as one bundle. You pass the child secure-payment tokens; the API returns a parent token and hosted URL.
+
+This is a distinct mechanism from a [batch payment](#post-v2secure-payments) (multiple `requests[]` in one create call). Multicall composes already-created payout links and supports cross-chain and Tron execution.
+
+### Request fields
+
+<ParamField body="childTokens" type="string[]" required>
+Ordered list of existing secure-payment tokens to combine. Minimum 2, maximum 1000 (the deployed default cap is 150 children). Duplicates are rejected.
+</ParamField>
+
+<ParamField body="requestedExecutionKind" type="string">
+How the bundle executes: `evm_same_chain`, `evm_cross_chain`, or `tron_batch`. When omitted, the execution kind is derived at payment time from the payer's source selection (Tron-only children → `tron_batch`; a chosen source chain/token → `evm_cross_chain`; otherwise `evm_same_chain`).
+</ParamField>
+
+<RequestExample>
+```bash cURL
+curl -X POST "https://api.request.network/v2/secure-payments/multicall-payouts" \
+  -H "x-api-key: YOUR_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "childTokens": [
+      "01JZ4PC7EXAMPLECHILD000001",
+      "01JZ4PC7EXAMPLECHILD000002"
+    ]
+  }'
+```
+</RequestExample>
+
+<ResponseExample>
+```json 201 Created
+{
+  "type": "multicall",
+  "token": "01JZ4PCMULTICALLPARENT0001",
+  "securePaymentUrl": "https://pay.request.network/?token=01JZ4PCMULTICALLPARENT0001",
+  "status": "pending",
+  "expiresAt": "2026-06-22T10:00:00.000Z",
+  "createdAt": "2026-06-15T10:00:00.000Z",
+  "items": [
+    { "securePaymentToken": "01JZ4PC7EXAMPLECHILD000001", "requestId": "01e273...", "position": 0 },
+    { "securePaymentToken": "01JZ4PC7EXAMPLECHILD000002", "requestId": "02f384...", "position": 1 }
+  ]
+}
+```
+</ResponseExample>
+
+The parent's `expiresAt` is the earliest expiry among its children.
+
+### Execution kinds
+
+| Kind | When | Behavior |
+| --- | --- | --- |
+| `evm_same_chain` | All children on one network and one currency | Settled as a single bundled batch transaction (plus any ERC-20 approvals) |
+| `evm_cross_chain` | Children span chains/currencies, or the payer pays from a different source | One cross-chain (Li.Fi) route is fetched per child and aggregated into one bundle (default cap 20 children) |
+| `tron_batch` | All children on Tron (same token) | Settled via the Tron batch payment contract |
+
+Supported payer source chains for cross-chain selection: `BASE`, `OPTIMISM`, `ARBITRUM`, `ETHEREUM`, `POLYGON`, `BNB`. Supported source tokens: `USDC`, `USDT`.
+
+### Validation errors
+
+Eligibility failures return a structured envelope:
+
+```json 400 Bad Request
+{
+  "message": "Multicall validation failed",
+  "code": "multicall_validation_failed",
+  "failures": [
+    { "securePaymentToken": "01JZ4PC7EXAMPLECHILD000099", "reason": "already_paid" }
+  ]
+}
+```
+
+`failures[].reason` includes values such as `already_paid`, `secure_payment_expired`, `not_outgoing`, `compliance_failed`, and `not_payable_child`. Each `failures[]` entry also carries `messageKey`, `context`, and `recoveryAction` to help you present and resolve the failure. When a count limit is exceeded, the envelope instead carries a `cap` object together with a `failures` entry whose reason is `too_many_children` (child-count cap) or `cap_exceeded`:
+
+```json 400 Bad Request (cap exceeded)
+{
+  "message": "Multicall validation failed",
+  "code": "multicall_validation_failed",
+  "failures": [
+    { "securePaymentToken": "*", "reason": "too_many_children" }
+  ],
+  "cap": { "type": "child_count", "maximum": 150, "actual": 180, "reduceBy": 30 }
+}
+```
+
+### Paying a multicall link
+
+The payer settles the parent token through the standard payer routes:
+
+- `GET /v2/secure-payments/:token` returns the multicall details (children, totals, per-child eligibility).
+- `GET /v2/secure-payments/:token/pay` returns multicall calldata, including `executionKind`, the `children[]` (each with its own `paymentReference`), the top-level `references[]` array (one per child, in order), and — for cross-chain — a per-child `destinationCall`.
+
+---
+
+## GET /v2/secure-payments/multicall-payouts/:token
+
+Retrieve passive details for a multicall payout parent — children, totals, and per-child eligibility. This endpoint does **not** return quotes, calldata, or execution data; use `GET /v2/secure-payments/:token/pay` for calldata. Requires a SIWE wallet session (operator/Dashboard-facing).
+
+### Path parameters
+
+<ParamField path="token" type="string" required>
+Multicall parent token returned from `POST /v2/secure-payments/multicall-payouts`.
+</ParamField>
+
+<ResponseExample>
+```json 200 OK
+{
+  "paymentType": "multicall",
+  "token": "01JZ4PCMULTICALLPARENT0001",
+  "status": "pending",
+  "canExecute": true,
+  "expiresAt": "2026-06-22T10:00:00.000Z",
+  "createdAt": "2026-06-15T10:00:00.000Z",
+  "children": [
+    {
+      "securePaymentToken": "01JZ4PC7EXAMPLECHILD000001",
+      "requestId": "01e273...",
+      "position": 0,
+      "executable": true,
+      "blockReason": null,
+      "amount": "50",
+      "payee": "0xb07d2398d2004378cad234da0ef14f1c94a530e4"
+    }
+  ],
+  "totals": {
+    "childCount": 2,
+    "blockedChildCount": 0
+  }
+}
+```
+</ResponseExample>
+
+<Note>
+The example is abbreviated. Each child also carries `messageKey`, `context`, `recoveryAction`, and `feePlan`, and `totals` also includes `byDestinationCurrency` and `amountSummary`.
+</Note>
+
+### Error responses
+
+- `403`: not authorized for this multicall parent
+- `404`: token not found
 - `429`: rate limited

--- a/docs.json
+++ b/docs.json
@@ -114,6 +114,7 @@
                 "pages": [
                   "api-features/secure-payment-pages",
                   "api-features/secure-payment-integration-guide",
+                  "api-features/safe-multisig-payments",
                   "api-features/secure-payment-supported-networks-and-currencies"
                 ]
               },
@@ -135,6 +136,15 @@
                 "group": "Advanced",
                 "pages": [
                   "api-features/commerce-payments"
+                ]
+              },
+              {
+                "group": "Orchestrators",
+                "pages": [
+                  "orchestrators/overview",
+                  "orchestrators/fees",
+                  "orchestrators/client-id-linking",
+                  "orchestrators/whitelabel-branding"
                 ]
               }
             ]

--- a/glossary.mdx
+++ b/glossary.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Glossary"
+description: "Definitions of Request Network terms — parties, protocol, payments, and cryptography concepts."
 ---
 
 ## Parties of a Request
@@ -147,6 +148,18 @@ The Request Protocol uses IPFS to ensure data accessibility.
 ### Multi-signature
 
 Multi-signature (multisig) wallets allow multiple parties to require more than one key to authorize a transaction. The needed number of signatures is agreed upon at the creation of the wallet. Multi-signature addresses have a much greater resistance to theft.
+
+### Account Abstraction (ERC-4337)
+
+Account Abstraction lets a smart contract act as a wallet (a "smart account"), enabling features such as transaction batching and gas sponsorship that externally-owned accounts (EOAs) cannot do natively. The Secure Payment page can execute supported EVM payments through an ERC-4337 smart account so approval, funding, and settlement run as a single operation. See [Smart account payments](/api-features/secure-payment-pages#smart-account-payments).
+
+### EIP-2612 Permit
+
+[EIP-2612](https://eips.ethereum.org/EIPS/eip-2612) lets a token holder approve a spender with an off-chain signature instead of an on-chain `approve()` transaction, removing the gas cost of the approval step. Tokens such as USDC support it; tokens such as USDT do not. See [Gasless token approvals](/api-features/secure-payment-pages#gasless-token-approvals-eip-2612).
+
+### Gnosis Safe
+
+A [Safe](https://safe.global/) is a widely used smart-contract multisig wallet that requires multiple owner signatures to execute a transaction. Request Network supports paying a secure payment from a Safe via the [Safe multisig payments](/api-features/safe-multisig-payments) flow.
 
 ### Private Key
 

--- a/orchestrators/client-id-linking.mdx
+++ b/orchestrators/client-id-linking.mdx
@@ -1,0 +1,72 @@
+---
+title: "Client ID linking"
+description: "Link platform Client IDs to your orchestrator — directly or via onboarding link intents — so your fees and branding apply to their payments."
+---
+
+## Overview
+
+To apply your [orchestrator fees](/orchestrators/fees) and [branding](/orchestrators/whitelabel-branding) to a platform's payments, link that platform's [Client ID](/api-features/client-id-management) (`cli_*` token) to your orchestrator. There are two ways to link: directly, when you already have the client ID, or via an onboarding **link intent**, when a recipient creates and links the client ID themselves.
+
+All linking endpoints use the `x-orchestrator-key` header.
+
+<Note>
+Linking is **one-to-one from the client ID side**: a client ID can be actively linked to at most one orchestrator. Re-linking a client ID that is already linked to a *different* orchestrator is rejected; re-linking to the *same* orchestrator is idempotent.
+</Note>
+
+## List linked client IDs
+
+```bash
+curl -X GET "https://api.request.network/v2/orchestrators/client-ids?page=1&limit=20" \
+  -H "x-orchestrator-key: orc_YOUR_ORCHESTRATOR_KEY"
+```
+
+Results are paginated with `page` and `limit`.
+
+## Link an existing client ID
+
+When the platform has already shared its `cli_*` token with you, link it directly:
+
+```bash
+curl -X POST "https://api.request.network/v2/orchestrators/client-ids" \
+  -H "x-orchestrator-key: orc_YOUR_ORCHESTRATOR_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{ "clientId": "cli_PLATFORM_CLIENT_ID" }'
+```
+
+## Onboard with a link intent
+
+When you want a recipient to create and link a client ID themselves, create a **link intent**. It returns a single-use onboarding URL you hand to the recipient; redeeming it creates a client ID under the name you chose and links it to your orchestrator.
+
+```bash
+curl -X POST "https://api.request.network/v2/orchestrators/client-id-link-intents" \
+  -H "x-orchestrator-key: orc_YOUR_ORCHESTRATOR_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{ "clientIdName": "Acme Store" }'
+```
+
+The response contains an onboarding `url` carrying a single-use access token. Share it with the recipient to complete onboarding.
+
+<Note>
+A link intent is single-use and expires. Once redeemed, the new client ID is linked to your orchestrator and appears in `GET /v2/orchestrators/client-ids`.
+</Note>
+
+## Unlink a client ID
+
+```bash
+curl -X DELETE "https://api.request.network/v2/orchestrators/client-ids/cli_PLATFORM_CLIENT_ID" \
+  -H "x-orchestrator-key: orc_YOUR_ORCHESTRATOR_KEY"
+```
+
+Unlinking revokes the active link. The client ID itself continues to exist and work; it simply no longer carries your orchestrator's fees and branding.
+
+## Related
+
+<CardGroup cols={2}>
+  <Card title="Orchestrator fees" href="/orchestrators/fees" icon="percent">
+    Apply fees and per-client-ID overrides to linked client IDs.
+  </Card>
+
+  <Card title="Client ID Management" href="/api-features/client-id-management" icon="id-card">
+    How platforms create and manage the `cli_*` client IDs you link.
+  </Card>
+</CardGroup>

--- a/orchestrators/fees.mdx
+++ b/orchestrators/fees.mdx
@@ -1,0 +1,97 @@
+---
+title: "Orchestrator fees"
+description: "Configure orchestrator fees and per-client-ID overrides: rates, caps, fee bearer, flow direction, and how fee layers resolve."
+---
+
+## Overview
+
+As an [orchestrator](/orchestrators/overview), you can attach fees to the payments made under the client IDs you've linked. Fees are configured with the `x-orchestrator-key` header on the `/v2/orchestrators/fee-configs` endpoints.
+
+Orchestrator fees are separate from — and stack with — the Request Network [protocol fee](/api-features/protocol-fees) and any per-request [platform fee](/api-features/platform-fees). On the orchestrator API you manage **orchestrator fees only**; the protocol fee is administered by Request Network.
+
+## Fee layers and precedence
+
+A payment can be subject to up to three fee layers. They resolve from most to least specific:
+
+1. **Per-client-ID override** — an orchestrator fee scoped to a single linked client ID. Wins its slot over the orchestrator default.
+2. **Orchestrator default** — an orchestrator fee that applies to all of the orchestrator's linked client IDs.
+3. **Protocol fee** — set by Request Network (falls back to the standard protocol default when none is configured).
+
+There is no per-client-ID protocol fee — client IDs can only override orchestrator fees.
+
+## Fee configuration fields
+
+<ParamField body="bps" type="integer" required>
+Fee rate in basis points, `0`–`10000` (`10000` = 100%). For example, `250` is 2.5%.
+</ParamField>
+
+<ParamField body="usdCap" type="string">
+Optional maximum fee in USD (as a string). Caps the fee for large payments.
+</ParamField>
+
+<ParamField body="feeBearer" type="string" required>
+Who absorbs the fee: `payer` (added on top of what the payer pays) or `recipient` (deducted from what the recipient receives).
+</ParamField>
+
+<ParamField body="flow" type="string" required>
+Which payment direction the fee applies to: `incoming` (get-paid flows) or `outgoing` (pay/payout flows). **Immutable** — see below.
+</ParamField>
+
+<ParamField body="evmRecipientAddress" type="string">
+EVM address that receives the fee. At least one of `evmRecipientAddress` or `tronRecipientAddress` is required.
+</ParamField>
+
+<ParamField body="tronRecipientAddress" type="string">
+Tron address that receives the fee. At least one of `evmRecipientAddress` or `tronRecipientAddress` is required.
+</ParamField>
+
+<Note>
+A fee config's identity is its combination of fee type, `flow`, and `feeBearer`. These are **immutable** — to change `flow` or `feeBearer`, disable the existing config and create a new one. You can update `bps`, `usdCap`, recipient addresses, and `status`.
+</Note>
+
+## Fee bearer and flow semantics
+
+- **`flow: incoming`** applies to payments you receive ("get paid"); its default bearer is the recipient.
+- **`flow: outgoing`** applies to payouts you send ("pay"); its default bearer is the payer.
+- **`feeBearer: payer`** adds the fee on top of the amount the payer pays.
+- **`feeBearer: recipient`** deducts the fee from the amount the recipient receives. A recipient-borne fee cannot exceed the gross amount.
+
+## Managing fee configs
+
+```bash
+# Create an orchestrator default fee (2.5%, payer-borne, on incoming payments)
+curl -X POST "https://api.request.network/v2/orchestrators/fee-configs" \
+  -H "x-orchestrator-key: orc_YOUR_ORCHESTRATOR_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "bps": 250,
+    "feeBearer": "payer",
+    "flow": "incoming",
+    "evmRecipientAddress": "0x742d35CC6634c0532925a3B844BC9e7595f8fA40"
+  }'
+```
+
+| Operation | Endpoint |
+| --- | --- |
+| Create a fee or per-client-ID override | `POST /v2/orchestrators/fee-configs` |
+| List fee configs (filter with `?clientId`) | `GET /v2/orchestrators/fee-configs` |
+| Update a fee config | `PATCH /v2/orchestrators/fee-configs/:id` |
+| Disable a fee config | `DELETE /v2/orchestrators/fee-configs/:id` |
+
+To scope a fee to a single linked client ID (an **override** rather than the orchestrator-wide default), provide that `clientId` when creating, listing, or disabling the config.
+
+## Related
+
+<CardGroup cols={3}>
+  <Card title="Protocol fees" href="/api-features/protocol-fees" icon="building-columns">
+    Request Network's protocol-level fee, rate, and cap.
+  </Card>
+
+  <Card title="Platform fees" href="/api-features/platform-fees" icon="percent">
+    Per-request integrator fees via feePercentage/feeAddress.
+  </Card>
+
+  <Card title="Fee breakdowns" href="/api-features/fee-breakdowns" icon="receipt">
+    Where fee line items appear in API responses.
+  </Card>
+</CardGroup>

--- a/orchestrators/overview.mdx
+++ b/orchestrators/overview.mdx
@@ -1,0 +1,80 @@
+---
+title: "Orchestrators overview"
+description: "Orchestrators are fee and branding partners in Request Network. Link client IDs, configure fees, and apply whitelabel branding across the platforms you serve."
+---
+
+## What is an orchestrator?
+
+An **orchestrator** is a fee and branding partner in Request Network. It is a first-class account that can:
+
+- **Link client IDs** — associate the developer [Client IDs](/api-features/client-id-management) (`cli_*` tokens) of the platforms you serve with your orchestrator.
+- **Configure fees** — set [orchestrator fees](/orchestrators/fees) (and per-client-ID overrides) that apply to payments made under those client IDs.
+- **Apply branding** — give the hosted [Secure Payment](/tools/secure-payments) experience your own [whitelabel branding](/orchestrators/whitelabel-branding).
+
+This is aimed at platforms, PSPs, and partners who orchestrate payments on behalf of multiple downstream merchants and want consistent fees and branding across them.
+
+<Note>
+"Orchestrator" here is the formal fee/branding partner account described on this page. It builds on — but is broader than — the lightweight "orchestrator pattern" of binding a single Client ID to a payee destination described in [Client ID Management](/api-features/client-id-management#orchestrator-pattern).
+</Note>
+
+## Getting provisioned
+
+Orchestrator accounts and their API keys are provisioned by Request Network — they are not self-service. [Get in touch](https://request.network) to have an orchestrator created for you.
+
+Once provisioned, you authenticate to the orchestrator endpoints with a secret key sent in the `x-orchestrator-key` header:
+
+```bash
+curl -X GET "https://api.request.network/v2/orchestrators/client-ids" \
+  -H "x-orchestrator-key: orc_YOUR_ORCHESTRATOR_KEY"
+```
+
+<Warning>
+Your orchestrator key (prefixed `orc_`) is a server-side secret. The full key value is shown only once, at creation time. Store it in a secret manager, never expose it in client-side code, and contact Request Network to rotate it if it is compromised.
+</Warning>
+
+## The orchestrator API surface
+
+All partner-facing orchestrator endpoints live under `/v2/orchestrators` and are authenticated with the `x-orchestrator-key` header:
+
+| Endpoint | Purpose |
+| --- | --- |
+| `GET /v2/orchestrators/client-ids` | List the client IDs linked to your orchestrator |
+| `POST /v2/orchestrators/client-ids` | Link an existing `cli_*` client ID |
+| `DELETE /v2/orchestrators/client-ids/:clientId` | Unlink a client ID |
+| `POST /v2/orchestrators/client-id-link-intents` | Create an onboarding link intent |
+| `POST /v2/orchestrators/fee-configs` | Create an orchestrator fee or per-client-ID override |
+| `GET /v2/orchestrators/fee-configs` | List your fee configs (optionally `?clientId`) |
+| `PATCH /v2/orchestrators/fee-configs/:id` | Update a fee config |
+| `DELETE /v2/orchestrators/fee-configs/:id` | Disable a fee config |
+
+See [Client ID linking](/orchestrators/client-id-linking) and [Orchestrator fees](/orchestrators/fees) for details.
+
+## How orchestrators apply at payment time
+
+**Fees** are applied only when the secure payment is created with **paired authentication** — both your `x-orchestrator-key` and the platform's `x-client-id` headers. A client-ID-only call cannot carry an orchestrator key (it is rejected), so it receives no orchestrator fee. The orchestrator's active fee configuration is resolved and baked into the payment at creation time:
+
+```bash
+curl -X POST "https://api.request.network/v2/secure-payments" \
+  -H "x-orchestrator-key: orc_YOUR_ORCHESTRATOR_KEY" \
+  -H "x-client-id: cli_PLATFORM_CLIENT_ID" \
+  -H "Content-Type: application/json" \
+  -d '{ "requests": [ { "destinationId": "...", "amount": "100" } ] }'
+```
+
+**Branding** is resolved from the active client-ID → orchestrator link when the hosted Secure Payment page loads, so your branding applies to a linked client ID's payments even without paired authentication.
+
+## Related
+
+<CardGroup cols={3}>
+  <Card title="Orchestrator fees" href="/orchestrators/fees" icon="percent">
+    Configure orchestrator fees and per-client-ID overrides.
+  </Card>
+
+  <Card title="Client ID linking" href="/orchestrators/client-id-linking" icon="link">
+    Link client IDs directly or via onboarding link intents.
+  </Card>
+
+  <Card title="Whitelabel branding" href="/orchestrators/whitelabel-branding" icon="palette">
+    Theme the Secure Payment page with your branding.
+  </Card>
+</CardGroup>

--- a/orchestrators/whitelabel-branding.mdx
+++ b/orchestrators/whitelabel-branding.mdx
@@ -1,0 +1,70 @@
+---
+title: "Whitelabel branding"
+description: "Theme the hosted Secure Payment page with your own colors, logo, and legal links as an orchestrator or per linked client ID."
+---
+
+## Overview
+
+As an [orchestrator](/orchestrators/overview), you can whitelabel the hosted [Secure Payment](/tools/secure-payments) page with your own colors, logo, and legal links. Branding can be set at the orchestrator level (applies to all your linked client IDs) or overridden per linked client ID.
+
+Branding is resolved server-side and delivered embedded in the `GET /v2/secure-payments/:token` response, so the hosted page renders your theme without any extra call.
+
+## Color tokens
+
+Branding defines five color tokens. Each must be a 3- or 6-digit hex color. The page derives additional shades (hovers, borders, modal colors, and a light/dark scheme) automatically from these five values.
+
+| Token | Default | Used for |
+| --- | --- | --- |
+| `pageBackground` | `#f3f4f6` | Page background |
+| `surfaceBackground` | `#ffffff` | Cards and panels |
+| `primaryAction` | `#00d395` | Primary buttons (Pay, Approve) |
+| `primaryText` | `#475569` | Headings and amounts |
+| `secondaryText` | `#94a3b8` | Labels and helper text |
+
+<Note>
+These are the theme-token names applied by the Secure Payment page. The underlying stored branding fields use `Color`-suffixed names — in particular `surfaceBackground` is stored as `cardBackgroundColor` (and `pageBackground` → `pageBackgroundColor`, `primaryAction` → `primaryActionColor`, and so on).
+</Note>
+
+## Logo and legal links
+
+| Field | Rules |
+| --- | --- |
+| `logoPath` | Footer/icon image. Must be a raster image: `.png`, `.jpg`, `.jpeg`, `.webp`, or `.avif` (SVG is rejected). |
+| `termsPath` | Terms link. Must end in `.html`. |
+| `privacyPath` | Privacy link. Must end in `.html`. |
+
+All three are **relative paths that must start with `/branding/`** — they cannot be absolute URLs or protocol-relative, cannot contain a query (`?`) or hash (`#`), and cannot contain path traversal (`..`).
+
+<Warning>
+Asset files must be **bundled with the deployed Secure Payment app** under `public/branding/{brand}/`. There is no remote-URL fetch — a path that points to a missing file renders as broken branding, not a fallback. Coordinate logo/legal asset bundling with Request Network when onboarding your branding.
+</Warning>
+
+## Request Network attribution
+
+`displayRequestBranding` (boolean) controls whether the footer shows **"Made easy by Request Network"**. It defaults to off for orchestrator-branded payments. Set it to `true` to keep the attribution.
+
+## Resolution priority
+
+Branding is selected **one row at a time**, most specific wins:
+
+1. **Client branding** — if a linked client ID has its own branding row, it is used. Any field left unset in that row falls back to the **Secure Payment defaults** (not to the orchestrator's values).
+2. **Orchestrator branding** — used only when the client ID has no branding row of its own.
+3. **Secure Payment defaults** (and the platform's default legal links) — used when neither is set.
+
+In other words, defining client-level branding replaces the orchestrator branding entirely for that client ID, so set every field you want at the level you use.
+
+## Setting branding
+
+Branding is managed through your orchestrator surface using the `x-orchestrator-key` header. Provide a `clientId` to set a per-client-ID override; omit it to set the orchestrator-level branding that applies to all your linked client IDs. Because logo and legal asset files must be bundled into the deployed app (see warning above), coordinate branding setup with Request Network during onboarding.
+
+## Related
+
+<CardGroup cols={2}>
+  <Card title="Secure Payment" href="/tools/secure-payments" icon="lock">
+    The hosted page your branding themes.
+  </Card>
+
+  <Card title="Orchestrators overview" href="/orchestrators/overview" icon="diagram-project">
+    How orchestrators, client IDs, fees, and branding fit together.
+  </Card>
+</CardGroup>

--- a/release-notes/request-api.mdx
+++ b/release-notes/request-api.mdx
@@ -7,6 +7,49 @@ This page tracks notable changes to the Request Network v2 API.
 
 ## Recent updates
 
+<Update label="2026-Q2 • Orchestrators" description="Fee & branding partner platform">
+
+### New Features
+
+- **Orchestrators** — a fee and branding partner layer. Provisioned by Request Network and authenticated with an `x-orchestrator-key`, orchestrators link platform Client IDs (`POST /v2/orchestrators/client-ids` and onboarding link intents), configure orchestrator fees and per-client-ID overrides (`/v2/orchestrators/fee-configs`), and apply whitelabel branding. See [Orchestrators](/orchestrators/overview).
+- **Configurable orchestrator fee model** — basis-point rates, optional USD caps, `feeBearer` (payer/recipient), and `flow` (incoming/outgoing), resolving as per-client-ID override → orchestrator default → protocol fee. See [Orchestrator fees](/orchestrators/fees).
+
+</Update>
+
+<Update label="2026-Q2 • Multicall payouts" description="Bundle payouts across chains and on Tron">
+
+### New Features
+
+- **Multicall payouts** — `POST /v2/secure-payments/multicall-payouts` combines multiple existing payout links into one hosted link settled as a single bundle. Three execution kinds: `evm_same_chain`, `evm_cross_chain` (per-child Li.Fi routing), and `tron_batch`. See [Multicall payouts](/api-features/payouts#multicall-payouts).
+
+</Update>
+
+<Update label="2026-Q2 • Safe & gasless" description="Safe multisig payers and gasless approvals">
+
+### New Features
+
+- **Safe multisig payments** — pay a secure payment from an existing Gnosis Safe: request Safe-ready calldata with `isSafe=true`, execute on your Safe, and track settlement by recording `safeTxHash` on the intent endpoint (`423 Locked` while in progress). See [Safe multisig payments](/api-features/safe-multisig-payments).
+- **Gasless token approvals (EIP-2612)** — on the smart-account path, permit-enabled tokens (e.g. USDC) authorize via an off-chain signature with no separate approval transaction. See [Gasless token approvals](/api-features/secure-payment-pages#gasless-token-approvals-eip-2612).
+
+</Update>
+
+<Update label="2026-Q2 • Tokens & compliance" description="USDT0 and Merkle Science KYT">
+
+### New Features
+
+- **USDT0** is supported as a payment currency (alias of USDT) on Arbitrum One, Optimism, and Polygon, and is part of the cross-chain currency set. See [Supported Chains and Currencies](/resources/supported-chains-and-currencies).
+- **Merkle Science** is available as a multi-chain KYT screening provider alongside the default Hypernative — select it with `screeningProvider` on a destination's access policy. See [Compliance-gated payments](/use-cases/compliance-gated-payments).
+
+</Update>
+
+<Update label="2026-Q2 • Whitelabel branding" description="Theme the Secure Payment page">
+
+### New Features
+
+- **Whitelabel branding** for the Secure Payment page — five color tokens plus logo and legal links, set at the orchestrator level or per client ID and delivered with the secure-payment metadata. See [Whitelabel branding](/orchestrators/whitelabel-branding).
+
+</Update>
+
 <Update label="2026-Q2" description="Tron gas fee transparency">
 
 ### Improvements
@@ -62,7 +105,8 @@ The v2 API exposes endpoints across these resource groups (see [Endpoints (V2)](
 - **Requests** (`/v2/request`) — create, query, update, get calldata
 - **Payments** (`/v2/payments`) — search and reconcile
 - **Payouts** (`/v2/payouts`, `/v2/payouts/batch`, `/v2/payouts/recurring`) — single, batch (EVM-only), recurring
-- **Secure Payments** (`/v2/secure-payments`, `/v2/secure-payments/payouts`) — incoming and outgoing hosted links
+- **Secure Payments** (`/v2/secure-payments`, `/v2/secure-payments/payouts`, `/v2/secure-payments/multicall-payouts`) — incoming, outgoing, and multicall hosted links
+- **Orchestrators** (`/v2/orchestrators`) — link client IDs and configure orchestrator fees (orchestrator-key auth)
 - **Currencies** (`/v2/currencies`) — supported tokens and conversion routes
 - **Commerce Payments** (`/v2/commerce-payments`) — authorize/capture/void/refund (preview)
 - **Payer** (`/v2/payer`) — crypto-to-fiat KYC and bank account flows

--- a/resources/supported-chains-and-currencies.mdx
+++ b/resources/supported-chains-and-currencies.mdx
@@ -14,10 +14,10 @@ Request Network supports payment destinations on **8 networks** — 7 EVM chains
 | Network | Chain ID | Network ID | USDC | USDT | Notes |
 | --- | --- | --- | --- | --- | --- |
 | Ethereum | `1` | `mainnet` | ✓ | ✓ | |
-| Arbitrum One | `42161` | `arbitrum-one` | ✓ | ✓ | Also supports USDT0 |
-| Optimism | `10` | `optimism` | ✓ | ✓ | |
+| Arbitrum One | `42161` | `arbitrum-one` | ✓ | ✓ | USDT0 payment currency also available |
+| Optimism | `10` | `optimism` | ✓ | ✓ | USDT0 payment currency also available |
 | Base | `8453` | `base` | ✓ | ✓ | |
-| Polygon | `137` | `matic` | ✓ | ✓ | |
+| Polygon | `137` | `matic` | ✓ | ✓ | USDT0 payment currency also available |
 | BNB Smart Chain | `56` | `bsc` | ✓ | ✓ | |
 | **Tron** | `728126428` | `tron` | ✓ | ✓ | TRC-20 tokens, `T...` addresses |
 
@@ -28,6 +28,10 @@ Request Network supports payment destinations on **8 networks** — 7 EVM chains
 | Sepolia | `11155111` | `sepolia` | FAU, USDC, USDT |
 
 All token addresses above are mainnet contracts. Use them as the `tokenAddress` when creating a payment destination via the [Auth API](https://auth.request.network/open-api/#tag/payee-destination).
+
+<Note>
+**USDT0** is supported as a payment currency (an alias of USDT) on **Arbitrum One**, **Optimism**, and **Polygon** — for example `USDT0-arbitrum-one`, `USDT0-optimism`, `USDT0-matic`. It is also part of the cross-chain currency set (USDC, USDT, USDT0). USDT0 is a payment/cross-chain currency, not a separate payee-destination token — receiving destinations are registered in USDC or USDT.
+</Note>
 
 ## Feature support per chain
 
@@ -141,6 +145,8 @@ Typical fields include:
 "USDC-base"
 "USDT-arbitrum-one"
 "USDT0-arbitrum-one"
+"USDT0-optimism"
+"USDT0-matic"
 ```
 
 ```javascript Tron examples

--- a/tools/dashboard.mdx
+++ b/tools/dashboard.mdx
@@ -97,7 +97,7 @@ The **Pay** tab is your outgoing-payments view. Create a single-recipient payout
   <img src="/images/dashboard/pay-list.webp" alt="Pay list (outgoing payouts)" />
 </Frame>
 
-The Dashboard UI today supports single-recipient payouts only on both EVM and Tron. For batch payouts (one signature, many EVM recipients), use the API directly — see [Batch payouts](/use-cases/batch-payouts).
+The Dashboard supports single-recipient payouts on both EVM and Tron, and lets you select multiple pending payouts and settle them together as a [multicall payout](/api-features/payouts#multicall-payouts) — reviewing every recipient before signing. For fully programmatic batch payouts, you can also call the API directly — see [Batch payouts](/use-cases/batch-payouts).
 
 ## What the Dashboard does *not* do
 

--- a/tools/secure-payments.mdx
+++ b/tools/secure-payments.mdx
@@ -100,17 +100,23 @@ Tron is fully supported as both a **source** and a **destination** for single-re
 **Multi-recipient Tron Secure Payments are not supported.** A Secure Payment link with multiple `requests[]` entries pointing at Tron destinations is rejected at creation time with a 400. EVM batches up to 200 payees per link work as expected.
 </Warning>
 
+## Multicall payouts
+
+When several outgoing payout links are combined into a [multicall payout](/api-features/payouts#multicall-payouts), the payer opens one Secure Payment link that lists every recipient and settles the whole bundle in a single flow. The page shows a per-recipient breakdown (including each payout's reference), totals, and — for cross-chain bundles — the Li.Fi routing, then a single confirm step. Bundles settle same-chain, across chains, or as a Tron batch depending on the recipients and the payer's chosen source.
+
 ## Compliance-gated payments (KYT)
 
 When the merchant has enabled a Know Your Transaction policy on the receiving destination, the secure payment app screens the connected wallet before showing payment options. Wallets that fail the screen see a policy-failure view and cannot reach the sign step. Optional privacy flags can also keep the payment amount and the payee address masked until the screening passes.
 
 See [Compliance-gated payments](/use-cases/compliance-gated-payments) for the merchant-side configuration and [Hypernative Standard Screening Policy](/use-cases/hypernative-standard-screening-policy) for the default KYT categories and thresholds.
 
-## Smart accounts (gasless on EVM)
+## Smart accounts & gasless approvals (EVM)
 
-For supported EVM destinations, Secure Payment can route payments through an [Account Abstraction](https://www.alchemy.com/overviews/what-is-account-abstraction) smart account so the payer doesn't need to hold gas-token balance. The flow is invisible to the payer beyond a slightly different transaction signature step. The integration uses Pimlico for bundling and Alchemy gas policies for sponsorship — see [Secure payment pages](/api-features/secure-payment-pages#smart-account-payments) for the full spec.
+For supported EVM payments, Secure Payment can route through an [ERC-4337](https://www.alchemy.com/overviews/what-is-account-abstraction) smart account derived from the payer's connected wallet and bundled via Pimlico, so the approval, funding, and payment execute as a single operation. The flow is invisible to the payer beyond the signature step.
 
-Smart-account routing is EVM-only. Tron payments use the standard TronWeb path.
+On this path, ERC-20 approvals are **gasless** for tokens that support [EIP-2612 `permit`](/api-features/secure-payment-pages#gasless-token-approvals-eip-2612) (such as USDC) — the payer signs instead of broadcasting a separate approval transaction. Tokens without permit (such as USDT) use a one-time on-chain approval. See [Secure payment pages](/api-features/secure-payment-pages#smart-account-payments) for the full spec.
+
+Smart-account routing is EVM-only; Tron payments use the standard TronWeb path. To pay from an existing **Gnosis Safe multisig**, use the [Safe multisig payments](/api-features/safe-multisig-payments) API flow.
 
 ## Error states
 

--- a/use-cases/batch-payouts.mdx
+++ b/use-cases/batch-payouts.mdx
@@ -5,7 +5,7 @@ description: "Pay many recipients in one signed transaction. Marketplaces paying
 
 ## What you'll build
 
-A workflow for paying many recipients at once with a single payer signature — gas-sponsored, atomic, on EVM. Either hand the payer a hosted batch URL on `pay.request.network` (recommended), or pay programmatically by getting calldata and broadcasting it yourself.
+A workflow for paying many recipients at once with a single payer signature — atomic, on EVM. Either hand the payer a hosted batch URL on `pay.request.network` (recommended), or pay programmatically by getting calldata and broadcasting it yourself.
 
 **Audience:** marketplaces paying out sellers, agencies paying contractors, refund campaigns, payroll-adjacent flows, any scenario where you'd otherwise sign N transactions back-to-back.
 
@@ -21,6 +21,10 @@ A workflow for paying many recipients at once with a single payer signature — 
 | **Direct Execution** (advanced) | [`POST /v2/payouts/batch`](/api-features/payouts#batch-payout) | Approval calldata + a single batch payment transaction you broadcast from your wallet |
 
 Pick **hosted batch link** for most scenarios — the payer reviews recipients and the transaction on the Secure Payment Page before signing. Pick **direct execution** only when your backend already signs payouts in fully automated environments with appropriate security controls.
+
+<Tip>
+**Bundling payouts across chains or on Tron?** [Multicall payouts](/api-features/payouts#multicall-payouts) combine multiple existing payout links into one link with cross-chain (Li.Fi) routing or Tron batch execution — a separate mechanism from the same-network batch endpoints below. See the [Secure Payments reference](/api-reference/secure-payments#post-v2secure-paymentsmulticall-payouts).
+</Tip>
 
 ## Prerequisites
 
@@ -124,9 +128,9 @@ await batchTx.wait();
 ## Wallet infrastructure compatibility
 
 <Note>
-At the moment, the Secure Payment Page and Dashboard are not compatible with Safe multisigs.
+The hosted Secure Payment Page and Dashboard execute through the payer's connected wallet (including an automatic [smart account](/api-features/secure-payment-pages#smart-account-payments) on supported EVM chains), so you cannot connect an existing Gnosis Safe multisig directly in the UI.
 
-For corporate treasury management and operational wallet infrastructure, we recommend using vault providers such as Utila, DFNS, or Fireblocks. Request Network is fully compatible with WalletConnect-based wallet infrastructure.
+To pay from a Safe multisig, use the API: request Safe-ready calldata and track settlement with the [Safe multisig payments](/api-features/safe-multisig-payments) flow, executing the transaction on your own Safe. For broader corporate treasury and operational wallet infrastructure, Request Network is also compatible with WalletConnect-based vault providers such as Utila, DFNS, or Fireblocks.
 </Note>
 
 ## Real-world examples

--- a/use-cases/compliance-gated-payments.mdx
+++ b/use-cases/compliance-gated-payments.mdx
@@ -111,7 +111,7 @@ Treat KYT as a first-line filter that blocks the most obvious cases, layered wit
 
 ## Hypernative Standard policy
 
-Request Network's recommended KYT screening provider is **Hypernative**. The **Hypernative Standard** policy defines the high-risk categories and related exposure thresholds used for wallet screening. You can select an alternative multi-chain provider, **Merkle Science**, by setting `screeningProvider: "merklescience"` on the access policy (see [the table above](#configure-a-kyt-gated-destination)).
+Request Network offers two KYT screening providers: **Hypernative** and **Merkle Science** (a multi-chain option). When `mode` is `kyt_all_wallets`, you must set `screeningProvider` to one of them — there is no default. The **Hypernative Standard** policy defines the high-risk categories and related exposure thresholds applied when you screen with Hypernative.
 
 See [Hypernative Standard Screening Policy](/use-cases/hypernative-standard-screening-policy) for the full category list, exposure thresholds, and limitations.
 

--- a/use-cases/compliance-gated-payments.mdx
+++ b/use-cases/compliance-gated-payments.mdx
@@ -43,6 +43,7 @@ curl -X POST "https://auth.request.network/v1/payee-destination" \
     "chainId": 1,
     "accessPolicy": {
       "mode": "kyt_all_wallets",
+      "screeningProvider": "hypernative",
       "hideUntilApproved": true,
       "hidePayeeAddress": true
     }
@@ -52,6 +53,7 @@ curl -X POST "https://auth.request.network/v1/payee-destination" \
 | Field | Type | Description |
 | --- | --- | --- |
 | `mode` | `"off"` \| `"kyt_all_wallets"` | `off` is the default (no screening). `kyt_all_wallets` screens every payer wallet that connects. |
+| `screeningProvider` | `"hypernative"` \| `"merklescience"` | KYT provider used for screening. **Required when `mode` is `kyt_all_wallets`** (omit it when `mode` is `off`). Choose `hypernative` or `merklescience` (Merkle Science, a multi-chain option). |
 | `hideUntilApproved` | `boolean` | When `true`, the payment metadata (amount, currency, recipient) is hidden until the payer's wallet has passed screening. |
 | `hidePayeeAddress` | `boolean` | When `true`, the payee wallet address is masked throughout the payer flow — no ENS resolution, no copy button, no explorer link. |
 
@@ -109,7 +111,7 @@ Treat KYT as a first-line filter that blocks the most obvious cases, layered wit
 
 ## Hypernative Standard policy
 
-Request Network's default KYT screening provider is Hypernative. The **Hypernative Standard** policy defines the high-risk categories and related exposure thresholds used for wallet screening.
+Request Network's recommended KYT screening provider is **Hypernative**. The **Hypernative Standard** policy defines the high-risk categories and related exposure thresholds used for wallet screening. You can select an alternative multi-chain provider, **Merkle Science**, by setting `screeningProvider: "merklescience"` on the access policy (see [the table above](#configure-a-kyt-gated-destination)).
 
 See [Hypernative Standard Screening Policy](/use-cases/hypernative-standard-screening-policy) for the full category list, exposure thresholds, and limitations.
 

--- a/use-cases/no-code-payment-links.mdx
+++ b/use-cases/no-code-payment-links.mdx
@@ -54,7 +54,7 @@ A repeatable workflow for sending one-off crypto payment links to customers, con
 
     - **Amount** — what you want to be paid (e.g. `500`)
     - **Reference** — your invoice number or any tracking string
-    - **Payer identifier** (optional) — the customer's email or your internal ID
+    - **Payer identifier** (optional) — your internal order or invoice ID
 
     <Frame>
       <img src="/images/dashboard/get-paid-new.webp" alt="Create new request form" />

--- a/use-cases/programmatic-payment-links.mdx
+++ b/use-cases/programmatic-payment-links.mdx
@@ -48,7 +48,7 @@ const response = await fetch("https://api.request.network/v2/secure-payments", {
       },
     ],
     reference: order.id,
-    payerIdentifier: customer.email,
+    payerIdentifier: customer.id,
   }),
 });
 
@@ -78,7 +78,7 @@ response = requests.post(
             }
         ],
         "reference": order.id,
-        "payerIdentifier": customer.email,
+        "payerIdentifier": customer.id,
     },
 )
 
@@ -98,7 +98,7 @@ curl -X POST "https://api.request.network/v2/secure-payments" \
       }
     ],
     "reference": "ORDER-2026-042",
-    "payerIdentifier": "alice@example.com"
+    "payerIdentifier": "user_12345"
   }'
 ```
 </CodeGroup>


### PR DESCRIPTION
## What & why

Syncs `docs.request.network` with stack changes shipped since the last docs update (May 2026), and removes guidance that suggested using a customer email / PII as a reference or identifier. Content was generated from a verified, code-grounded spec pass across `request-api`, `request-auth-api`, `request-dashboard`, and `request-secure-payment`, then run through an adversarial multi-agent review loop (findings applied below).

## New feature docs

- **Safe multisig payments** — new page `api-features/safe-multisig-payments.mdx`: `isSafe=true` calldata, recording `safeTxHash` on the intent endpoint, `423 Locked` polling, `safePaymentDeadline`.
- **EIP-2612 gasless approvals + smart accounts** — clarified on `secure-payment-pages.mdx` and `tools/secure-payments.mdx` (automatic ERC-4337 path; permit-enabled tokens like USDC are gasless, USDT/DAI fall back to on-chain approve). Fixed an inaccurate "Alchemy gas policies" mention.
- **Multicall payouts** — `POST /v2/secure-payments/multicall-payouts` + `GET .../:token`, the three execution kinds (`evm_same_chain` / `evm_cross_chain` / `tron_batch`), caps, validation envelope, and payer flow across the API reference, `payouts.mdx`, `batch-payouts.mdx`, and the tool pages.
- **USDT0** — documented as a payment-currency alias of USDT on Arbitrum One, Optimism, and Polygon (not a registerable destination token).
- **Merkle Science** — added as a multi-chain KYT `screeningProvider` alongside Hypernative.
- **Orchestrators** — new nav section: `overview`, `fees`, `client-id-linking`, `whitelabel-branding` (partner surface `/v2/orchestrators` with `x-orchestrator-key`; orchestrator creation/keys/protocol-fees are RN-admin-only and intentionally not documented).
- **Release notes** updated with dated Q2 2026 entries; `docs.json` nav updated.

## PII

Removed every suggestion to put a customer email / PII into a reference or identifier field (payer identifier, `clientUserId`, `customerInfo` examples). **No PII warning/alert callouts were added** — the docs simply no longer suggest it. Legitimate mentions kept (platform email/password login, "send the link via email", wallet "no email no password").

## Accuracy fixes surfaced by review (verified against source)

- Secure-payments `/:token`, `/:token/pay`, `/:token/intent` are `x-client-id`-only (not `x-api-key`); `POST /v2/secure-payments` also accepts the orchestrator pair.
- Corrected the Tron secure-payments batch error string; corrected multicall validation-envelope examples.
- Orchestrator **fees** require paired auth (`x-orchestrator-key` + `x-client-id`); branding applies via the client-ID→orchestrator link. Whitelabel branding resolves **whole-row** (client row OR orchestrator row), not per-field.

## Flagged for a separate look (pre-existing, NOT changed here)

These are pre-existing claims outside this sync's scope; I did not flip them, but they look inaccurate against the code:

1. **EVM↔Tron cross-chain via Li.Fi** is claimed in `tools/secure-payments.mdx`, `use-cases/multi-chain-checkout.mdx`, and `use-cases/no-code-payment-links.mdx`, but `request-api` has no Tron handling in `lifi.core`, `CROSS_CHAIN_SUPPORTED_NETWORKS` excludes Tron, and a unit test asserts `isLifiRoutable('tron') === false`. `secure-payment-supported-networks-and-currencies.mdx` already says "Tron payments are same-chain." Worth confirming whether EVM↔Tron cross-chain is actually shipped before correcting the docs.
2. **Session cookie name** — several curl examples use `Cookie: session=...`, but the cookie is `session_token` (as `quickstart.mdx` already shows).
3. **Pimlico** is named as the bundler/paymaster on the smart-account pages (pre-existing); fine to keep, flagging only for awareness.

## Validation

`npx mintlify broken-links` passes. Review loop reported PII-clean and confirmed the orchestrator/multicall/branding fixes against source.
