### PR TITLE
feat: tron sponsored tx doc

### DIFF
--- a/api-features/protocol-fees.mdx
+++ b/api-features/protocol-fees.mdx
@@ -37,6 +37,14 @@ For larger payments with stablecoins, the fee is capped:
 
 - Payment of 100,000 USDC -> Fee capped at 25 USDC (not 50 USDC)
 
+## Tron-specific fees
+
+Transaction fees on Tron are paid in TRX and can be high when a wallet burns TRX directly for energy and bandwidth.
+
+To prevent payers from needing TRX before they can broadcast a transaction, Request Network covers the required Tron resources through dedicated providers. We use [CatFee](https://catfee.io/) to sponsor energy and [Tron Energy Rent](https://tronenergyrent.com/) to sponsor bandwidth. This provider-based flow makes Tron transactions cost less than if the payer burned TRX directly.
+
+To cover these sponsored resource costs, Request Network applies a fixed $5 payer-borne fee to every Tron transaction. This fee is lower than the TRX amount the payer would typically spend when paying Tron network resources directly.
+
 ## Shifting the Fee to the Payee
 
 If you want the payee to bear the protocol fee instead of the payer, simply reduce the invoice amount by 5bps (0.05%) before creating the request.

--- a/api-features/protocol-fees.mdx
+++ b/api-features/protocol-fees.mdx
@@ -37,14 +37,6 @@ For larger payments with stablecoins, the fee is capped:
 
 - Payment of 100,000 USDC -> Fee capped at 25 USDC (not 50 USDC)
 
-## Tron-specific fees
-
-Transaction fees on Tron are paid in TRX and can be high when a wallet burns TRX directly for energy and bandwidth.
-
-To prevent payers from needing TRX before they can broadcast a transaction, Request Network covers the required Tron resources through dedicated providers. We use [CatFee](https://catfee.io/) to sponsor energy and [Tron Energy Rent](https://tronenergyrent.com/) to sponsor bandwidth. This provider-based flow makes Tron transactions cost less than if the payer burned TRX directly.
-
-To cover these sponsored resource costs, Request Network applies a fixed $5 payer-borne fee to every Tron transaction. This fee is lower than the TRX amount the payer would typically spend when paying Tron network resources directly.
-
 ## Shifting the Fee to the Payee
 
 If you want the payee to bear the protocol fee instead of the payer, simply reduce the invoice amount by 5bps (0.05%) before creating the request.
@@ -89,3 +81,11 @@ Every API response includes the fee details in the metadata:
   }
 }
 ```
+
+## Tron-specific fees
+
+Transaction fees on Tron are paid in TRX and can be high when a wallet burns TRX directly for energy and bandwidth.
+
+To prevent payers from needing TRX to broadcast a transaction, Request Network covers the required Tron resources through dedicated providers. We use [CatFee](https://catfee.io/) to sponsor energy and [Tron Energy Rent](https://tronenergyrent.com/) to sponsor bandwidth. This provider-based flow makes Tron transactions cost less than if the payer burned TRX directly.
+
+To cover these sponsored resource costs, Request Network applies a fixed $5 payer-borne fee to every Tron payment. This fee is lower than the TRX amount the payer would typically spend when paying Tron network resources directly.

--- a/api-features/protocol-fees.mdx
+++ b/api-features/protocol-fees.mdx
@@ -86,6 +86,8 @@ Every API response includes the fee details in the metadata:
 
 Transaction fees on Tron are paid in TRX and can be high when a wallet burns TRX directly for energy and bandwidth.
 
-To prevent payers from needing TRX to broadcast a transaction, Request Network covers the required Tron resources through dedicated providers. We use [CatFee](https://catfee.io/) to sponsor energy and [Tron Energy Rent](https://tronenergyrent.com/) to sponsor bandwidth. This provider-based flow makes Tron transactions cost less than if the payer burned TRX directly.
+To prevent payers from needing TRX to broadcast a transaction, Request Network covers the required Tron resources through dedicated providers such as [CatFee](https://catfee.io/) and [Tron Energy Rent](https://tronenergyrent.com/). This provider-based flow makes Tron transactions cost less than if you burned TRX directly.
 
-To cover these sponsored resource costs, Request Network applies a fixed $5 payer-borne fee to every Tron payment. This fee is lower than the TRX amount the payer would typically spend when paying Tron network resources directly.
+<Note>
+To cover these sponsored resource costs, Request Network applies a fixed $5 fee to every Tron payment. This Tron-specific fee is charged in addition to the standard protocol fee and is lower than the TRX amount you would typically spend when paying Tron network resources directly.
+</Note>

--- a/api-features/protocol-fees.mdx
+++ b/api-features/protocol-fees.mdx
@@ -86,7 +86,7 @@ Every API response includes the fee details in the metadata:
 
 Transaction fees on Tron are paid in TRX and can be high when a wallet burns TRX directly for energy and bandwidth.
 
-To prevent payers from needing TRX to broadcast a transaction, Request Network covers the required Tron resources through dedicated providers such as [CatFee](https://catfee.io/) and [Tron Energy Rent](https://tronenergyrent.com/). This provider-based flow makes Tron transactions cost less than if you burned TRX directly.
+To prevent you from needing TRX to broadcast a transaction, Request Network covers the required Tron resources through dedicated providers such as [CatFee](https://catfee.io/) and [Tron Energy Rent](https://tronenergyrent.com/). This provider-based flow makes Tron transactions cost less than if you burned TRX directly.
 
 <Note>
 To cover these sponsored resource costs, Request Network applies a fixed $5 fee to every Tron payment. This Tron-specific fee is charged in addition to the standard protocol fee and is lower than the TRX amount you would typically spend when paying Tron network resources directly.


### PR DESCRIPTION
### TL;DR

Added documentation explaining Tron-specific protocol fees and how Request Network handles Tron resource sponsorship.

### What changed?

A new section, "Tron-specific fees," has been added to the protocol fees documentation. It explains that:
- Tron transaction fees are paid in TRX and can be costly when a wallet burns TRX directly for energy and bandwidth.
- Request Network sponsors the required Tron resources via [CatFee](https://catfee.io/) for energy and [Tron Energy Rent](https://tronenergyrent.com/) for bandwidth, removing the need for payers to hold TRX.
- A fixed $5 payer-borne fee is applied to every Tron payment to cover these sponsored resource costs, which is less than what a payer would typically spend burning TRX directly.

### How to test?

Navigate to the Protocol Fees documentation page and verify the new "Tron-specific fees" section appears at the bottom with accurate content and working links to CatFee and Tron Energy Rent.

### Why make this change?

Payers using Tron may be confused about why a fixed $5 fee is applied or why they don't need TRX to broadcast transactions. This documentation clarifies the fee structure and the rationale behind using sponsored resource providers on Tron.