### PR TITLE
docs: sync docs with 2026-07-07 stack release batch

### DIFF
--- a/api-features/crosschain-payments.mdx
+++ b/api-features/crosschain-payments.mdx
@@ -11,6 +11,10 @@ description: "Multi-network payment routing with automatic bridging via LiFi"
 
 Crosschain payments allow users to pay a request using a stablecoin from a different blockchain network than the one specified on the request. For example, a payer can pay a request for USDC on Base using USDT from their Optimism wallet. Crosschain routing is powered by [LiFi](https://li.fi/), which aggregates bridges and DEXs to find optimal routes.
 
+<Info>
+Cross-chain routing uses the Across bridge (LiFi routes are restricted to Across for predictable, supported settlement). A circuit breaker automatically degrades gracefully if the LiFi routing service is impaired—routes may temporarily be unavailable during an outage, but payments remain detectable and the API stays responsive.
+</Info>
+
 ## Benefits
 
 - **Flexibility:** Payers can pay with their preferred stablecoin on any supported chain.

--- a/api-features/payee-destinations.mdx
+++ b/api-features/payee-destinations.mdx
@@ -156,7 +156,9 @@ Returns the active payee destination for the authenticated wallet, or `null` if 
 
 ### GET /v1/payee-destination/payout-lookup
 
-Retrieve the active destination preference for a payout recipient wallet. Returns only the routing fields needed to prefill payout creation, or `null` if the recipient has no active destination.
+Retrieve the active destination preference for a payout **recipient** wallet. Returns only the routing fields needed to prefill payout creation, or `null` if the recipient has no active destination.
+
+Like the other endpoints on this page, this requires a SIWE wallet session (httpOnly cookie). Unlike the other endpoints, the `walletAddress` query parameter is the *recipient* you are looking up — not the authenticated caller — so a payout initiator can resolve where a recipient wants to be paid.
 
 <ParamField query="walletAddress" type="string" required>
 Recipient wallet address to check for an active destination (Ethereum or Tron format).

--- a/api-features/payee-destinations.mdx
+++ b/api-features/payee-destinations.mdx
@@ -101,6 +101,10 @@ Optional KYT (Know Your Transaction) compliance policy applied to payments into 
     `off` (default): no screening. `kyt_all_wallets`: every payer wallet is screened.
   </ParamField>
 
+  <ParamField body="screeningProvider" type='"hypernative" | "merklescience"'>
+    KYT provider used for screening. Required when `mode` is `kyt_all_wallets` (must be omitted or `null` when `mode` is `off`). `merklescience` (Merkle Science) is available where enabled for your account.
+  </ParamField>
+
   <ParamField body="hideUntilApproved" type="boolean">
     When `true`, payment metadata is hidden in the payer UI until the wallet passes screening.
   </ParamField>
@@ -120,6 +124,7 @@ Optional KYT (Know Your Transaction) compliance policy applied to payments into 
   "chainId": 8453,
   "accessPolicy": {
     "mode": "kyt_all_wallets",
+    "screeningProvider": "hypernative",
     "hideUntilApproved": true,
     "hidePayeeAddress": true
   },
@@ -148,6 +153,24 @@ Returns the updated destination object (same format as POST response).
 ### GET /v1/payee-destination
 
 Returns the active payee destination for the authenticated wallet, or `null` if none exists.
+
+### GET /v1/payee-destination/payout-lookup
+
+Retrieve the active destination preference for a payout recipient wallet. Returns only the routing fields needed to prefill payout creation, or `null` if the recipient has no active destination.
+
+<ParamField query="walletAddress" type="string" required>
+Recipient wallet address to check for an active destination (Ethereum or Tron format).
+</ParamField>
+
+```json Response (200)
+{
+  "destinationId": "0x742d...8f44e@eip155:1#4CA88C9C:0xa0b8...6eb48",
+  "walletAddress": "0x742d35cc6634c0532925a3b844bc454e4438f44e",
+  "tokenAddress": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+  "chainId": 1,
+  "claimed": true
+}
+```
 
 ### GET /v1/payee-destination/lookup
 

--- a/api-features/payouts.mdx
+++ b/api-features/payouts.mdx
@@ -67,7 +67,7 @@ The response includes `requestId` and a `transactions` array with executable cal
 Pay multiple recipients in a single blockchain transaction. All payments must be on the same network.
 
 <Warning>
-**EVM-only.** Batch payouts work on EVM chains. Tron batch payouts are not supported — the API rejects them with `Batch payments are not supported for TRON networks. Please submit individual payment requests.` For Tron, submit individual `POST /v2/payouts` calls per recipient.
+**This endpoint is EVM-only.** `POST /v2/payouts/batch` settles a single same-network EVM transaction and rejects Tron with `Batch payments are not supported for TRON networks. Please submit individual payment requests.` To batch Tron payouts, use [multicall payouts](#multicall-payouts) with the `tron_batch` execution kind instead; single Tron payouts via `POST /v2/payouts` also remain available.
 </Warning>
 
 ```bash

--- a/api-features/query-requests.mdx
+++ b/api-features/query-requests.mdx
@@ -29,6 +29,8 @@ Typical fields include:
 - `requestAmount` — the original requested amount in invoice currency
 - `detectionSource` — how the payment was confirmed (`"request-network"` or `"lifi"`)
 - `note` — additional context for non-standard settlements (e.g., LiFi fallback)
+- `payerAddress` — the resolved payer wallet address for the payment (`null` when it can't be determined, e.g. for some contract-mediated flows)
+- `paidAmount`, `receivedAmount`, `excessAmount` — the amount paid by the payer, the raw amount received by the payment route, and any route-delivered amount above what was applied to the request
 - optional metadata such as `customerInfo` and `reference`
 </Step>
 
@@ -66,6 +68,7 @@ For wallet-level reconciliation views, use [GET /v2/payments](https://api.reques
 
 - Use `requestId` for deterministic lookup.
 - Keep idempotent reconciliation logic in case the same request is processed multiple times by your workers.
+- The `GET /v2/request` list endpoint accepts an optional `walletAddress` query parameter to scope results to a single payee wallet. Omit it to list across the authenticated identity's requests.
 
 ## Related Pages
 

--- a/api-features/webhooks-events.mdx
+++ b/api-features/webhooks-events.mdx
@@ -22,6 +22,10 @@ The Request Network webhook system emits **12 event types** across four categori
 
 The `.client_id` and `.checkout` variants are emitted in addition to the base `.confirmed` / `.partial` events when the request was created via a Client ID or as a checkout / secure payment, respectively. They include extra metadata (`clientId`, `origin`).
 
+<Note>
+Payment webhook payloads include `payerAddress` — the resolved payer wallet address (`null` when it can't be determined). See the [Webhooks reference](/api-reference/webhooks) for the full payload schema.
+</Note>
+
 For full payload schemas and headers, see the [Webhooks reference](/api-reference/webhooks).
 
 ## How It Works

--- a/api-reference/authentication.mdx
+++ b/api-reference/authentication.mdx
@@ -10,7 +10,7 @@ Request Network API supports two authentication modes:
 - `x-api-key` for server-side integrations
 - `x-client-id` for browser/client integrations (with `Origin` header)
 
-Use this page as the canonical auth reference. Client IDs are managed in the [Request Dashboard](https://dashboard.request.network); webhooks are managed programmatically via the [Auth API](https://auth.request.network/open-api/#tag/webhook) (`POST /v1/webhook` with the `x-client-id` header).
+Use this page as the canonical auth reference. Client IDs are managed in the [Request Dashboard](https://dashboard.request.network). Webhooks can be managed no-code from the [Dashboard](/tools/dashboard#webhooks) or programmatically via the [Auth API](https://auth.request.network/open-api/#tag/webhook) (`POST /v1/webhook` with the `x-client-id` header).
 
 ## Choose the Right Method
 
@@ -56,14 +56,16 @@ For browser-based requests, `Origin` is part of the request context and is requi
 
 Request Network enforces rate limits on `x-client-id` requests to keep the API responsive for every integrator. By default, authenticated `x-client-id` integrators get an SLA of **300 requests per minute (5 requests per second)** in production.
 
-Higher-throughput tiers are available for integrators who need them:
+Several tiers exist. Most integrators run on **Default**; contact us to move to a higher-throughput tier if you need one:
 
 | Tier | Rate |
 | --- | --- |
 | Basic | 2 req/sec (120 req/min) |
-| Default | 5 req/sec (300 req/min) |
+| Default (standard SLA) | 5 req/sec (300 req/min) |
 | Premium | 10 req/sec (600 req/min) |
 | High-volume | 20 req/sec (1,200 req/min) |
+
+Tiers are listed from lowest to highest throughput; `Default` is the standard SLA applied to authenticated integrators unless you have been assigned another tier.
 
 Rate limits are scoped per client ID and IP address, so usage from one client ID on one IP doesn't affect your limit on another IP. If you sustain a breach of your limit, requests from that client ID and IP are temporarily blocked (5 minutes by default) before being allowed again. Some endpoints, such as client ID management, use a more relaxed limit than the general default shown above.
 

--- a/api-reference/authentication.mdx
+++ b/api-reference/authentication.mdx
@@ -52,6 +52,25 @@ For browser-based requests, `Origin` is part of the request context and is requi
 - `x-client-id`: Client identifier used for client-side auth
 - `Origin`: required with Client ID flows in browser contexts
 
+## Rate limits
+
+Request Network enforces rate limits on `x-client-id` requests to keep the API responsive for every integrator. By default, authenticated `x-client-id` integrators get an SLA of **300 requests per minute (5 requests per second)** in production.
+
+Higher-throughput tiers are available for integrators who need them:
+
+| Tier | Rate |
+| --- | --- |
+| Basic | 2 req/sec (120 req/min) |
+| Default | 5 req/sec (300 req/min) |
+| Premium | 10 req/sec (600 req/min) |
+| High-volume | 20 req/sec (1,200 req/min) |
+
+Rate limits are scoped per client ID and IP address, so usage from one client ID on one IP doesn't affect your limit on another IP. If you sustain a breach of your limit, requests from that client ID and IP are temporarily blocked (5 minutes by default) before being allowed again. Some endpoints, such as client ID management, use a more relaxed limit than the general default shown above.
+
+<Note>
+The production default is 5 req/sec. Non-production environments (development and test) run at a higher limit to support testing. Contact us if your integration needs a higher tier than the production default.
+</Note>
+
 ## Common Authentication Errors
 
 ### 401 Unauthorized
@@ -66,7 +85,7 @@ For browser-based requests, `Origin` is part of the request context and is requi
 
 ### 429 Too Many Requests
 
-- Request rate exceeded for your credentials
+- Request rate exceeded for your credentials. See [Rate limits](#rate-limits).
 
 ## Security Guidance
 

--- a/release-notes/request-api.mdx
+++ b/release-notes/request-api.mdx
@@ -7,6 +7,21 @@ This page tracks notable changes to the Request Network v2 API.
 
 ## Recent updates
 
+<Update label="2026-Q3" description="Wallet reconciliation, rate limits, and hardened routing">
+
+### New Features
+
+- **Payer wallet address in reconciliation** — request status responses and payment webhook payloads now include `payerAddress`, the resolved wallet that paid (or `null` when it cannot be determined). See [Query requests](/api-features/query-requests) and [Webhooks & events](/api-features/webhooks-events).
+- **List requests by wallet (optional)** — the request list endpoint (`GET /v2/request`) now accepts an optional `walletAddress` filter to scope results to a single payee wallet; omit it to list across the authenticated identity scope.
+- **Tron batch payouts** — Tron payouts can now be bundled via multicall payouts using the `tron_batch` execution kind. See [Multicall payouts](/api-features/payouts#multicall-payouts).
+
+### Improvements
+
+- **Rate-limit SLA** — authenticated integrators (via `x-client-id`) are served at a 300 requests/min SLA, with higher tiers available on request. Limits are scoped per client ID and IP. See [Authentication](/api-reference/authentication).
+- **LiFi routing hardened** — cross-chain routing is now restricted to the Across bridge, and a circuit breaker degrades gracefully when LiFi is impaired so payments remain detectable. See [Cross-chain payments](/api-features/crosschain-payments).
+
+</Update>
+
 <Update label="2026-Q2 • Orchestrators" description="Fee & branding partner platform">
 
 ### New Features

--- a/tools/dashboard.mdx
+++ b/tools/dashboard.mdx
@@ -75,6 +75,17 @@ Advanced fields — `feePercentage`, `feeAddress`, `operatorWalletAddress`, `pay
 
 For the full field reference, see [Client ID Management](/api-features/client-id-management).
 
+## Webhooks
+
+The Dashboard manages webhooks from the **Webhooks** section on the **Manage Destination** page. Each webhook endpoint is tied to a specific Client ID.
+
+From this section you can:
+- **Add a webhook** — enter the endpoint URL and choose the Client ID it belongs to. The Dashboard shows the signing secret once, immediately after creation — save it, since it isn't displayed in full again afterward.
+- **Enable or disable** an existing webhook with a toggle, without deleting it.
+- **Delete** a webhook endpoint.
+
+See [Webhooks](/api-features/webhooks-events) for the payload format and how to verify signatures. Webhooks can also be managed programmatically via the [Auth API](https://auth.request.network/open-api/#tag/webhook).
+
 ## Get Paid
 
 The **Get Paid** tab is your incoming-payments view. Create a request — amount, currency, optional reference and payer identifier — and the Dashboard generates a `pay.request.network` link to share.
@@ -102,7 +113,6 @@ The Dashboard supports single-recipient payouts on both EVM and Tron, and lets y
 ## What the Dashboard does *not* do
 
 - It is not an admin / merchant control panel for downstream platforms — it's a user dashboard for your own wallet.
-- It does not manage webhooks today — webhooks are managed via the [Auth API](https://auth.request.network/open-api).
 - It does not host the payer-side checkout — that's [Secure Payment](/tools/secure-payments) at `pay.request.network`.
 
 ## Open the Dashboard


### PR DESCRIPTION
## What & why

The docs were already synced with the stack on **2026-07-01** ([#101](https://github.com/RequestNetwork/mintlify-docs/pull/101)). This PR adds **only the deltas from the 2026-07-07 release batch** — everything else was already covered. All changes land in existing pages: **no new pages, no `docs.json` nav change.**

Release batch covered:
- request-api **0.25.0**, request-auth-api **0.10.0**, request-dashboard **0.8.0**, request-secure-payment **0.10.0/0.10.1**

## Changes

| Page | Change |
| --- | --- |
| `release-notes/request-api.mdx` | New `2026-Q3` entry: payer wallet in reconciliation, optional `walletAddress` list filter, rate-limit SLA, hardened LiFi routing, Tron batch payouts via multicall |
| `api-reference/authentication.mdx` | New **Rate limits** section (300/min SLA default, Basic/Premium/High-volume tiers, per-client-id+IP scoping, ~5-min block) + 429 cross-link |
| `api-features/query-requests.mdx` | `payerAddress` and `paidAmount`/`receivedAmount`/`excessAmount` status fields; optional `walletAddress` filter on `GET /v2/request` |
| `api-features/webhooks-events.mdx` | Note that payment webhook payloads now include `payerAddress` (12-event table unchanged) |
| `tools/dashboard.mdx` | Corrected the stale "does not manage webhooks today" claim; documented the **Webhooks** section on Manage Destination (add / one-time secret / enable-disable / delete) |
| `api-features/payee-destinations.mdx` | `screeningProvider` (`hypernative`\|`merklescience`) access-policy field; `GET /v1/payee-destination/payout-lookup` endpoint |
| `api-features/crosschain-payments.mdx` | Note: LiFi routing restricted to Across + circuit-breaker graceful degradation |

## Verification

- Every field name, enum, and endpoint path verified against **shipped request-api 0.25.0** and request-auth-api source (not release-note titles). Notably confirmed `payerAddress` (present on both the request status response and the webhook payload at tag `0.25.0`) — the local request-api checkout was pre-0.25.0, so verification was done against the release tag.
- `mint broken-links` → **no broken links found.**
- Correctly excluded internal/gRPC-only surfaces (orchestrator webhooks) and did not assert a false `screeningProvider` default.

## Follow-up (out of scope)

`api-reference/openapi.v2.json` is manually maintained (`info.version` `0.13.0`) with no sync mechanism, and is out of band with the API. Refreshing it is a separate task from this content pass.
