### PR TITLE
docs: show payerAddress in webhook payload examples

### DIFF
--- a/api-reference/webhooks.mdx
+++ b/api-reference/webhooks.mdx
@@ -198,6 +198,7 @@ All payment events include an `explorer` field linking to [Request Scan](https:/
 - `paymentReference`: Short reference, also unique to a request, used to link payments to the request
 - `timestamp`: ISO 8601 formatted event timestamp
 - `paymentProcessor`: Either `request-network` (crypto) or `request-tech` (fiat)
+- `payerAddress`: Resolved payer wallet — the on-chain sender for plain direct payments, or the resolved payer for recurring and intent-based flows (Secure Payment Page, LiFi, Safe, ERC-4337, multicall). `null` when it cannot be determined. Included on `payment.confirmed` and `payment.partial` events (and their `.client_id` / `.checkout` variants).
 
 ### Payment Confirmed
 ```json
@@ -212,6 +213,7 @@ All payment events include an `explorer` field linking to [Request Scan](https:/
   "expectedAmount": "100.0",
   "timestamp": "2025-10-03T14:30:00Z",
   "txHash": "0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+  "payerAddress": "0x92Fc3406Fc6BB7A76aC63b2E8b9d02b1B9C3e4d5",
   "network": "ethereum",
   "currency": "USDC",
   "paymentCurrency": "USDC",
@@ -259,6 +261,7 @@ All payment events include an `explorer` field linking to [Request Scan](https:/
   "expectedAmount": "100.0",
   "timestamp": "2025-10-03T14:30:00Z",
   "txHash": "0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+  "payerAddress": "0x92Fc3406Fc6BB7A76aC63b2E8b9d02b1B9C3e4d5",
   "network": "ethereum",
   "currency": "USDC",
   "paymentCurrency": "USDC",


### PR DESCRIPTION
## What & why

Follow-up to [#103](https://github.com/RequestNetwork/mintlify-docs/pull/103). That PR documented `payerAddress` on the [Webhooks & Events](/api-features/webhooks-events) feature page, but the **payload examples** on the [Webhooks API reference](/api-reference/webhooks) still didn't show it. This adds it where it actually appears.

## Change

- Added `payerAddress` to the **Payment Confirmed** and **Payment Partial** JSON payload examples.
- Added a `payerAddress` entry to the **Common Fields** notes, describing what it resolves to and which events carry it.

## Which events carry it (verified against request-api `0.25.0`)

`payerAddress` is defined on `PaymentWebhookPayload` (`src/types/webhook.types.ts:63` at tag `0.25.0`), which is extended only by:

- `payment.confirmed`, `payment.partial`
- `payment.confirmed.client_id`, `payment.partial.client_id`
- `payment.confirmed.checkout`, `payment.partial.checkout`

It is **not** on `payment.failed`, `payment.refunded`, `payment.processing` (offramp payload), `request.recurring`, `compliance.updated`, or `payment_detail.updated` — so those examples are intentionally left unchanged.

## Verification

- All JSON payload blocks parse as valid JSON.
- `mint broken-links` → no broken links.
