### PR TITLE
docs(api): document payer EOA address in payment reconciliation

### DIFF
--- a/api-features/query-requests.mdx
+++ b/api-features/query-requests.mdx
@@ -30,6 +30,7 @@ Typical fields include:
 - `detectionSource` — how the payment was confirmed (`"request-network"` or `"lifi"`)
 - `note` — additional context for non-standard settlements (e.g., LiFi fallback)
 - `payerAddress` — the resolved payer wallet address for the payment (`null` when it can't be determined, e.g. for some contract-mediated flows)
+- `payerEoaAddress` — the payer's connected wallet address (`null` when unavailable). It can differ from `payerAddress` when a smart account is used.
 - `paidAmount`, `receivedAmount`, `excessAmount` — the amount paid by the payer, the raw amount received by the payment route, and any route-delivered amount above what was applied to the request
 - optional metadata such as `customerInfo` and `reference`
 </Step>

--- a/api-features/webhooks-events.mdx
+++ b/api-features/webhooks-events.mdx
@@ -23,7 +23,7 @@ The Request Network webhook system emits **12 event types** across four categori
 The `.client_id` and `.checkout` variants are emitted in addition to the base `.confirmed` / `.partial` events when the request was created via a Client ID or as a checkout / secure payment, respectively. They include extra metadata (`clientId`, `origin`).
 
 <Note>
-Payment webhook payloads include `payerAddress` — the resolved payer wallet address (`null` when it can't be determined). See the [Webhooks reference](/api-reference/webhooks) for the full payload schema.
+Payment webhook payloads include `payerAddress`, the address used to make the payment, and `payerEoaAddress`, the payer's connected wallet address. These can differ when a smart account is used. Both are `null` when unavailable. See the [Webhooks reference](/api-reference/webhooks) for the full payload schema.
 </Note>
 
 For full payload schemas and headers, see the [Webhooks reference](/api-reference/webhooks).

--- a/api-reference/webhooks.mdx
+++ b/api-reference/webhooks.mdx
@@ -199,6 +199,7 @@ All payment events include an `explorer` field linking to [Request Scan](https:/
 - `timestamp`: ISO 8601 formatted event timestamp
 - `paymentProcessor`: Either `request-network` (crypto) or `request-tech` (fiat)
 - `payerAddress`: Resolved payer wallet — the on-chain sender for plain direct payments, or the resolved payer for recurring and intent-based flows (Secure Payment Page, LiFi, Safe, ERC-4337, multicall). `null` when it cannot be determined. Included on `payment.confirmed` and `payment.partial` events (and their `.client_id` / `.checkout` variants).
+- `payerEoaAddress`: The payer's connected wallet address. It can differ from `payerAddress` when a smart account is used. `null` when unavailable. Included on `payment.confirmed` and `payment.partial` events (and their `.client_id` / `.checkout` variants).
 
 ### Payment Confirmed
 ```json
@@ -214,6 +215,7 @@ All payment events include an `explorer` field linking to [Request Scan](https:/
   "timestamp": "2025-10-03T14:30:00Z",
   "txHash": "0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
   "payerAddress": "0x92Fc3406Fc6BB7A76aC63b2E8b9d02b1B9C3e4d5",
+  "payerEoaAddress": "0x7A1F20C4D58E9B0A3C6D4E2F1B8A5C7D9E0F1234",
   "network": "ethereum",
   "currency": "USDC",
   "paymentCurrency": "USDC",
@@ -262,6 +264,7 @@ All payment events include an `explorer` field linking to [Request Scan](https:/
   "timestamp": "2025-10-03T14:30:00Z",
   "txHash": "0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
   "payerAddress": "0x92Fc3406Fc6BB7A76aC63b2E8b9d02b1B9C3e4d5",
+  "payerEoaAddress": "0x7A1F20C4D58E9B0A3C6D4E2F1B8A5C7D9E0F1234",
   "network": "ethereum",
   "currency": "USDC",
   "paymentCurrency": "USDC",

--- a/release-notes/request-api.mdx
+++ b/release-notes/request-api.mdx
@@ -11,7 +11,7 @@ This page tracks notable changes to the Request Network v2 API.
 
 ### New Features
 
-- **Payer wallet address in reconciliation** — request status responses and payment webhook payloads now include `payerAddress`, the resolved wallet that paid (or `null` when it cannot be determined). See [Query requests](/api-features/query-requests) and [Webhooks & events](/api-features/webhooks-events).
+- **Payer wallet details in reconciliation** — request status responses and payment webhook payloads include `payerAddress`, the address used to make the payment, and `payerEoaAddress`, the payer's connected wallet address. These can differ when a smart account is used. Both are `null` when unavailable. See [Query requests](/api-features/query-requests) and [Webhooks & events](/api-features/webhooks-events).
 - **List requests by wallet (optional)** — the request list endpoint (`GET /v2/request`) now accepts an optional `walletAddress` filter to scope results to a single payee wallet; omit it to list across the authenticated identity scope.
 - **Tron batch payouts** — Tron payouts can now be bundled via multicall payouts using the `tron_batch` execution kind. See [Multicall payouts](/api-features/payouts#multicall-payouts).
 


### PR DESCRIPTION
### TL;DR

Added documentation for the new `payerEoaAddress` field across API responses and webhook payloads.

### What changed?

A new `payerEoaAddress` field is now documented in the query requests reference, webhooks events overview, webhooks reference (including payload examples), and release notes. This field exposes the payer's connected wallet (EOA) address and is distinct from `payerAddress`, which reflects the on-chain sender. The two values can differ when a smart account is used to make a payment. Both fields return `null` when the respective address cannot be determined.

The release notes entry for payer wallet reconciliation was also updated to reflect that both `payerAddress` and `payerEoaAddress` are now included, replacing the previous description that only mentioned `payerAddress`.

### How to test?

- Trigger a payment using a smart account (e.g., ERC-4337 or Safe) and verify that the `payment.confirmed` or `payment.partial` webhook payload contains both `payerAddress` (the smart contract address) and `payerEoaAddress` (the connected EOA).
- Query a request after payment and confirm `payerEoaAddress` appears in the response fields alongside `payerAddress`.
- For a standard EOA payment, confirm both fields are present and may hold the same value.

### Why make this change?

Smart account usage means the on-chain sender (`payerAddress`) is often a contract rather than the user's actual wallet. Exposing `payerEoaAddress` gives integrators a reliable way to identify the human-controlled wallet behind a payment, which is important for reconciliation, compliance, and customer identification workflows.