### PR TITLE
chore:  update tron fixed fee value

### DIFF
--- a/api-features/protocol-fees.mdx
+++ b/api-features/protocol-fees.mdx
@@ -89,5 +89,5 @@ Transaction fees on Tron are paid in TRX and can be high when a wallet burns TRX
 To prevent you from needing TRX to broadcast a transaction, Request Network covers the required Tron resources through dedicated providers such as [CatFee](https://catfee.io/) and [Tron Energy Rent](https://tronenergyrent.com/). This provider-based flow makes Tron transactions cost less than if you burned TRX directly.
 
 <Note>
-To cover these sponsored resource costs, Request Network applies a fixed $5 fee to every Tron payment. This Tron-specific fee is charged in addition to the standard protocol fee and is lower than the TRX amount you would typically spend when paying Tron network resources directly.
+To cover these sponsored resource costs, Request Network applies a fixed $3.99 fee to every Tron payment. This Tron-specific fee is charged in addition to the standard protocol fee and is lower than the TRX amount you would typically spend when paying Tron network resources directly.
 </Note>


### PR DESCRIPTION
### TL;DR

Updated the fixed Tron payment fee from $5.00 to $3.99.

### What changed?

The documented fixed fee applied to every Tron payment to cover sponsored resource costs has been reduced from $5 to $3.99.

### How to test?

Review the `protocol-fees.mdx` page and confirm the Tron-specific fee note displays $3.99.

### Why make this change?

The fee amount was updated to reflect the current pricing for covering Tron network resource sponsorship through providers like CatFee and Tron Energy Rent.