### PR TITLE
feat: add freshness and attribution signals to the docs (REQ-272)

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -18,6 +18,9 @@
     }
   },
   "favicon": "/favicon.svg",
+  "metadata": {
+    "timestamp": true
+  },
   "fonts": {
     "heading": {
       "family": "Montserrat"
@@ -212,6 +215,13 @@
               "faq",
               "glossary"
             ]
+          },
+          {
+            "group": "📰 Release Notes",
+            "pages": [
+              "release-notes/index",
+              "release-notes/request-api"
+            ]
           }
         ]
       }
@@ -251,9 +261,12 @@
     "metatags": {
       "robots": "index, follow, max-snippet:-1, max-image-preview:large, max-video-preview:-1",
       "og:locale": "en_US",
-      "inLanguage": "en"
+      "inLanguage": "en",
+      "author": "Request Network",
+      "article:publisher": "https://request.network"
     },
     "organization": {
+      "id": "https://request.network/#organization",
       "name": "Request Network",
       "url": "https://request.network",
       "logo": "https://docs.request.network/logo/dark.svg",


### PR DESCRIPTION
Closes [REQ-272](https://linear.app/requestnetwork/issue/REQ-272/geoseo-add-e-e-a-t-author-freshness-signals-to-docs).

Stacked on #106. Review that one first.

E-E-A-T and freshness affect both search ranking and whether an answer engine trusts a source enough to cite it. The docs published neither a last-modified date nor any attribution.

## What this adds

| Change | Signal |
| --- | --- |
| `metadata.timestamp: true` | Visible last-modified date on every page |
| `seo.metatags.author`, `article:publisher` | Attribution |
| `seo.organization.id` | A stable `@id`, so the Organization structured data resolves to one node instead of a fresh anonymous one per page |
| Release Notes group under Resources | See below |

**On the release notes:** `release-notes/index` and `release-notes/request-api` were orphan pages. Since `seo.indexing` defaults to `navigable`, the two pages carrying the strongest freshness signal on the site were **not indexed at all**. Adding them to the nav fixes that. I did not flip `seo.indexing` to `"all"`, which would also index stale pages.

## Two deliberate omissions

**`seo.organization.legalName` is absent**, though the audit asks for it. The authoritative source — [request.network's legal notice](https://request.network/legal-notice/) — states only that *"Request Network is a Swiss Stiftung, whose headquarters is located at Baarerstrasse 82 ... registered under No. CHE-422.666.391"*. It never gives a registered entity name. The string "Request Network Foundation" appears in `faq.mdx`, but as prose describing who operates the gateways, not as a registry fact.

Publishing an unverified `legalName` in JSON-LD would work against the entity disambiguation this change exists to support — and against [REQ-269](https://linear.app/requestnetwork/issue/REQ-269/geo-establish-a-request-network-entity-in-wikidata-wikipedia) (Wikidata/Wikipedia entity), where a wrong legal name is worse than none. @rodrigopavezi: if you can confirm the registered name against the CHE registry, it's a one-line addition:

```json
"legalName": "<registered name>",
```

**Person/author structured data is not here** because Mintlify cannot express it. Verified against the schema `docs.json` declares: `seo.organization` accepts only `id`, `name`, `legalName`, `url`, `logo`, `sameAs`, and page frontmatter has no `author` field. The `Person` schema the Outrun audit flagged is therefore a platform request, not a repo change — it's item 7 of the [REQ-271](https://linear.app/requestnetwork/issue/REQ-271/geo-enable-mintlify-platform-ai-signals-not-settable-in-repo-robots-ai) support ticket.

## Notes

- `resources/community.mdx` is still an orphan page. Left alone — no view on whether that's intentional.
- Pre-existing nit not touched here: `seo.organization.sameAs` includes `https://request.network`, which duplicates `url`. Harmless, just redundant for entity resolution.

## Verification

- `mint validate` — passes
- `mint broken-links` — clean
- Every key added confirmed present, with matching type, in the schema at `https://mintlify.com/docs.json`
