### PR TITLE
test: add the repeatable docs-only LLM and GEO validation (REQ-169)

### DIFF
--- a/VALIDATION.md
+++ b/VALIDATION.md
@@ -1,0 +1,85 @@
+# Validation: AI discoverability & GEO
+
+This is a repo document, not a published page — it is not linked in `docs.json` navigation and should not be. It exists so a human or an agent can re-run, on demand, the checks that motivated the AI-discoverable-docs / GEO work (Linear REQ-159, REQ-169, REQ-271).
+
+## When to run this
+
+Run the full checklist below:
+
+- After any docs change that touches credentials, webhooks, or the payment-link flow (`use-cases/`, `api-features/`, `api-reference/authentication.mdx`, `api-reference/webhooks.mdx`, and anything `llms.txt` summarizes).
+- After each Mintlify platform change that could affect `robots.txt`, response headers, `llms.txt`/`llms-full.txt` generation, or redirects (Mintlify is a hosted platform — these can change independent of a docs PR).
+- Before and after any release that claims to move the GEO grade or fix an agent-discoverability regression.
+
+## Part 1 — the docs-only LLM check
+
+This is the actual done-condition for the MVP: can an LLM, using only the public docs site (no repo access, no SDK), build a correct server-side integration that creates a payment link and confirms payment?
+
+**How to run it:** Open a fresh Claude or ChatGPT session with web access enabled and nothing else attached (no project files, no repo, no custom instructions). Paste the prompt below verbatim.
+
+> I'm integrating payments into my backend using Request Network. I want to let a customer pay an invoice and get notified server-side when it's paid. Using only https://docs.request.network, walk me through building this: creating a payment link, finding out what credentials I need and where to get them, wiring up a webhook so my server knows the payment is confirmed, and handling the case where the customer pays cross-chain. Ask me for whatever credentials or IDs you need. Write the integration code (any backend language you like) and tell me exactly what to call and in what order.
+
+**Pass / fail rubric.** The run **passes** only if the assistant:
+
+- Asks the user for **only**: the Client ID, the webhook secret returned when registering the webhook, and the Destination ID from the Dashboard. (The Destination ID is a non-secret identifier — asking for it is correct, not a failure.)
+- **Never** asks for an API key, a private key, or a raw wallet address.
+- Treats webhooks as the source of truth for payment state — fulfillment happens on `payment.confirmed`, and `payment.partial` is treated as an intermediate state, not a trigger to fulfill.
+- Treats a cross-chain payment as **pending** until settled, not as final just because the payer was redirected back.
+- Calls the REST API directly (`fetch`/`axios`/`requests`/`curl` against `api.request.network` / `auth.request.network`) rather than reaching for an SDK that doesn't exist.
+- Verifies the webhook HMAC signature against the **raw** request body (not a re-serialized/parsed body) before trusting the payload.
+
+Any one of these violated is a **fail** for that run, even if the rest of the flow is correct — these are exactly the mistakes the docs rewrite (REQ-159 et al.) was meant to prevent.
+
+**Recording a run:** paste the transcript link (or a saved copy if the tool has no shareable link) and the date into the Results log below, plus a one-line note on what (if anything) failed.
+
+## Part 2 — the automated signal check
+
+`scripts/check-geo-signals.ts` checks the machine-readable signals (llms.txt, redirects, structured data, response headers) against a running deployment. It is fast, free, and doesn't need an LLM.
+
+```bash
+pnpm check-geo-signals
+# or, without pnpm:
+npx tsx scripts/check-geo-signals.ts
+
+# against a non-default target:
+BASE_URL=https://staging.docs.request.network pnpm check-geo-signals
+```
+
+Each check reports one of:
+
+- **PASS** — the signal is present and correct.
+- **FAIL** — the signal is missing or wrong. Non-zero exit code if any check is FAIL.
+- **PLATFORM-GATED** — the signal depends on a Mintlify platform capability that isn't available to this repo yet (the `<link rel="alternate" type="text/plain" href="/llms.txt">` head tag, per-bot `robots.txt` Allow lines, `/.well-known/security.txt`, and certain response headers). These are tracked in REQ-271 and are **expected to stay failing** (reported as PLATFORM-GATED, not FAIL) until that platform request lands — do not treat them as a regression in this repo.
+
+Note: the script's own header reminds you that redirect and rendered-HTML checks assert the **post-merge, deployed** state — running it against production before this PR stack merges will show real (and expected) FAILs for those checks. Re-run after merge + deploy for a meaningful result.
+
+## Part 3 — link + build checks
+
+```bash
+mint broken-links
+mint validate
+```
+
+- `mint broken-links` checks for dead internal links across the docs. Should be clean.
+- `mint validate` runs Mintlify's strict-mode build validation. It passes as of this stack. It did not on `main`: two "Invalid import path react" warnings from unused `snippets/` files failed strict mode, and those files have since been removed (REQ-270). Any failure now is a real regression.
+
+## Part 4 — the external GEO re-check
+
+Two independent, third-party-ish signals of how "AI-readable" the site is overall:
+
+1. **Outrun GEO checker** (or equivalent GEO/AEO grading tool). Baseline before this stack: **grade C, 172/257**. Re-run after deploy and record the new grade/score.
+2. **Mintlify's own agent-readiness score:**
+   ```bash
+   mint login   # human step — requires an interactive browser login, do not attempt in CI
+   mint score docs.request.network --format table
+   ```
+   `mint score` requires authentication and cannot be run unattended in CI; a human runs it locally after `mint login`.
+
+Record the grade/score and the delta from the previous entry in the Results log.
+
+## Results log
+
+Do not add a row until the run has actually happened. Never fabricate or estimate a result — an empty log is more useful than an invented one.
+
+| Date | What changed | LLM check verdict | Signal-check result | GEO grade | Notes |
+| --- | --- | --- | --- | --- | --- |
+| (baseline, pre-stack) | Baseline, before the AI-discoverable-docs / GEO stack | not run | not run | C / 172 (Outrun GEO checker) | Baseline measurement recorded before REQ-159/REQ-169/REQ-271 work started. No LLM check or signal-check existed yet. |

--- a/VALIDATION.md
+++ b/VALIDATION.md
@@ -48,6 +48,7 @@ Each check reports one of:
 
 - **PASS** — the signal is present and correct.
 - **FAIL** — the signal is missing or wrong. Non-zero exit code if any check is FAIL.
+- **INFO** — reported, never asserted. Used where the expected value depends on unconfirmed Mintlify behaviour: currently whether the `seo.organization` identity in `docs.json` overrides the default Organization structured data Mintlify generates from `docs.json` `name`. Never affects the exit code.
 - **PLATFORM-GATED** — the signal depends on a Mintlify platform capability that isn't available to this repo yet (the `<link rel="alternate" type="text/plain" href="/llms.txt">` head tag, per-bot `robots.txt` Allow lines, `/.well-known/security.txt`, and certain response headers). These are tracked in REQ-271 and are **expected to stay failing** (reported as PLATFORM-GATED, not FAIL) until that platform request lands — do not treat them as a regression in this repo.
 
 Note: the script's own header reminds you that redirect and rendered-HTML checks assert the **post-merge, deployed** state — running it against production before this PR stack merges will show real (and expected) FAILs for those checks. Re-run after merge + deploy for a meaningful result.

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "description": "Tooling for the Request Network Mintlify docs (e.g. Playwright screenshot capture).",
   "scripts": {
-    "capture-screenshots": "tsx scripts/capture-screenshots.ts"
+    "capture-screenshots": "tsx scripts/capture-screenshots.ts",
+    "check-geo-signals": "tsx scripts/check-geo-signals.ts"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/scripts/check-geo-signals.ts
+++ b/scripts/check-geo-signals.ts
@@ -1,0 +1,305 @@
+/**
+ * GEO / agent-discoverability signal check for the Request Network Mintlify docs.
+ *
+ * ============================================================================
+ * IMPORTANT: this script asserts the POST-MERGE, DEPLOYED target state.
+ * ============================================================================
+ * Several checks below (the redirects, the robots meta + Organization JSON-LD
+ * on rendered HTML, and possibly llms.txt/llms-full.txt depending on deploy
+ * timing) will legitimately FAIL if run against production BEFORE this PR
+ * stack has merged and Mintlify has rebuilt the site. A failing run before
+ * merge is expected and is not a regression — re-run after merge + deploy to
+ * get a meaningful result. See VALIDATION.md for how this fits into the
+ * broader verification process.
+ *
+ * Usage:
+ *   npx tsx scripts/check-geo-signals.ts
+ *   BASE_URL=https://staging.docs.request.network npx tsx scripts/check-geo-signals.ts
+ *   npx tsx scripts/check-geo-signals.ts https://staging.docs.request.network
+ *
+ * Exit code is non-zero only if a non-platform-gated check fails.
+ */
+
+const DEFAULT_BASE_URL = "https://docs.request.network";
+const BASE_URL = (process.argv[2] || process.env.BASE_URL || DEFAULT_BASE_URL).replace(/\/$/, "");
+
+type Status = "PASS" | "FAIL" | "PLATFORM-GATED";
+
+type Result = {
+  name: string;
+  status: Status;
+  reason: string;
+};
+
+const results: Result[] = [];
+
+function record(name: string, status: Status, reason: string) {
+  results.push({ name, status, reason });
+  const label = status.padEnd(15, " ");
+  console.log(`${label} ${name} — ${reason}`);
+}
+
+async function fetchText(url: string, init?: RequestInit): Promise<{ ok: boolean; status: number; body: string; headers: Headers; error?: string }> {
+  try {
+    const res = await fetch(url, init);
+    const body = await res.text();
+    return { ok: res.ok, status: res.status, body, headers: res.headers };
+  } catch (err) {
+    return { ok: false, status: 0, body: "", headers: new Headers(), error: (err as Error).message };
+  }
+}
+
+// --- Check 1: /llms.txt ---
+async function checkLlmsTxt() {
+  const url = `${BASE_URL}/llms.txt`;
+  const res = await fetchText(url);
+  if (res.error) {
+    record("llms.txt reachable", "FAIL", `network error — ${res.error}`);
+    return;
+  }
+  if (res.status !== 200) {
+    record("llms.txt reachable", "FAIL", `expected 200, got ${res.status}`);
+    return;
+  }
+  record("llms.txt reachable", "PASS", "200 OK");
+
+  const anchors = ["Request Network", "## Credentials", "RN_CLIENT_ID"];
+  for (const anchor of anchors) {
+    if (res.body.includes(anchor)) {
+      record(`llms.txt contains "${anchor}"`, "PASS", "found");
+    } else {
+      record(`llms.txt contains "${anchor}"`, "FAIL", "not found in body");
+    }
+  }
+}
+
+// --- Check 2: /llms-full.txt ---
+async function checkLlmsFullTxt() {
+  const url = `${BASE_URL}/llms-full.txt`;
+  const res = await fetchText(url);
+  if (res.error) {
+    record("llms-full.txt reachable", "FAIL", `network error — ${res.error}`);
+    return;
+  }
+  if (res.status === 200) {
+    record("llms-full.txt reachable", "PASS", "200 OK (Mintlify auto-generated)");
+  } else {
+    record("llms-full.txt reachable", "FAIL", `expected 200, got ${res.status}`);
+  }
+}
+
+// --- Check 3: redirects ---
+const REDIRECTS: Array<{ source: string; destination: string }> = [
+  { source: "/api-features/no-code-payment-links", destination: "/use-cases/no-code-payment-links" },
+  { source: "/api-features/programmatic-payment-links", destination: "/use-cases/programmatic-payment-links" },
+  { source: "/api-features/authentication", destination: "/api-reference/authentication" },
+];
+
+function locationMatches(location: string | null, destination: string): boolean {
+  if (!location) return false;
+  try {
+    const asUrl = new URL(location, BASE_URL);
+    return asUrl.pathname.replace(/\/$/, "") === destination.replace(/\/$/, "");
+  } catch {
+    return location.replace(/\/$/, "") === destination.replace(/\/$/, "");
+  }
+}
+
+async function checkRedirects() {
+  for (const { source, destination } of REDIRECTS) {
+    const url = `${BASE_URL}${source}`;
+    try {
+      const res = await fetch(url, { redirect: "manual" });
+      if (res.status >= 300 && res.status < 400) {
+        const location = res.headers.get("location");
+        if (locationMatches(location, destination)) {
+          record(`redirect ${source}`, "PASS", `${res.status} -> ${location}`);
+        } else {
+          record(`redirect ${source}`, "FAIL", `${res.status} -> ${location ?? "(no location header)"}, expected ${destination}`);
+        }
+      } else {
+        // Some hosts resolve redirects transparently even with redirect:"manual"
+        // (e.g. edge rewrites). Fall back to checking the final resolved URL.
+        const followed = await fetch(url, { redirect: "follow" });
+        const finalPath = new URL(followed.url).pathname.replace(/\/$/, "");
+        if (finalPath === destination.replace(/\/$/, "")) {
+          record(`redirect ${source}`, "PASS", `resolved (no 3xx observed) -> ${finalPath}`);
+        } else {
+          record(`redirect ${source}`, "FAIL", `expected 3xx to ${destination}, got ${res.status} and final path ${finalPath}`);
+        }
+      }
+    } catch (err) {
+      record(`redirect ${source}`, "FAIL", `network error — ${(err as Error).message}`);
+    }
+  }
+}
+
+// --- Check 4: rendered HTML signals ---
+const PAGES_TO_CHECK = ["/", "/use-cases/no-code-payment-links"];
+
+async function checkHtmlSignals() {
+  for (const path of PAGES_TO_CHECK) {
+    const url = `${BASE_URL}${path}`;
+    const res = await fetchText(url);
+    if (res.error) {
+      record(`HTML signals ${path}`, "FAIL", `network error — ${res.error}`);
+      continue;
+    }
+    if (res.status !== 200) {
+      record(`HTML signals ${path}`, "FAIL", `expected 200, got ${res.status}`);
+      continue;
+    }
+
+    const hasRobotsMeta =
+      /<meta[^>]+name=["']robots["'][^>]*content=["'][^"']*max-snippet:-1[^"']*["']/i.test(res.body);
+    record(
+      `${path} robots meta max-snippet:-1`,
+      hasRobotsMeta ? "PASS" : "FAIL",
+      hasRobotsMeta ? "found in <head>" : "not found",
+    );
+
+    const hasOrgJsonLd = /"@type"\s*:\s*"Organization"/.test(res.body);
+    record(
+      `${path} Organization JSON-LD`,
+      hasOrgJsonLd ? "PASS" : "FAIL",
+      hasOrgJsonLd ? 'found "@type":"Organization"' : "not found",
+    );
+  }
+}
+
+// --- Platform-gated checks (never fail the run) ---
+async function checkPlatformGated() {
+  // llms.txt <link rel="alternate"> in <head>
+  {
+    const res = await fetchText(`${BASE_URL}/`);
+    const hasLink =
+      !res.error &&
+      /<link[^>]+rel=["']alternate["'][^>]+type=["']text\/plain["'][^>]+href=["']\/llms\.txt["']/i.test(res.body);
+    record(
+      '<link rel="alternate" type="text/plain" href="/llms.txt">',
+      hasLink ? "PASS" : "PLATFORM-GATED",
+      hasLink ? "found in <head>" : "not present — gated behind Mintlify support request (REQ-271)",
+    );
+  }
+
+  // robots.txt per-bot Allow lines
+  {
+    const res = await fetchText(`${BASE_URL}/robots.txt`);
+    const bots = ["GPTBot", "OAI-SearchBot", "ClaudeBot", "PerplexityBot", "Google-Extended"];
+    if (res.error || res.status !== 200) {
+      record(
+        "robots.txt per-bot Allow lines",
+        "PLATFORM-GATED",
+        `robots.txt not reachable (status ${res.status}) — gated behind Mintlify support request (REQ-271)`,
+      );
+    } else {
+      const missing = bots.filter((bot) => !new RegExp(`User-agent:\\s*${bot}[\\s\\S]{0,200}?Allow:`, "i").test(res.body));
+      if (missing.length === 0) {
+        record("robots.txt per-bot Allow lines", "PASS", "all bots have explicit Allow lines");
+      } else {
+        record(
+          "robots.txt per-bot Allow lines",
+          "PLATFORM-GATED",
+          `missing explicit Allow lines for: ${missing.join(", ")} — gated behind Mintlify support request (REQ-271)`,
+        );
+      }
+    }
+  }
+
+  // /.well-known/security.txt
+  {
+    const res = await fetchText(`${BASE_URL}/.well-known/security.txt`);
+    const ok = !res.error && res.status === 200;
+    record(
+      "/.well-known/security.txt",
+      ok ? "PASS" : "PLATFORM-GATED",
+      ok ? "200 OK" : `status ${res.status} — gated behind Mintlify support request (REQ-271)`,
+    );
+  }
+
+  // Security headers
+  {
+    const res = await fetchText(`${BASE_URL}/`);
+    if (res.error) {
+      record("X-Content-Type-Options / Referrer-Policy headers", "PLATFORM-GATED", `network error — ${res.error}`);
+    } else {
+      const xcto = res.headers.get("x-content-type-options");
+      const rp = res.headers.get("referrer-policy");
+      const ok = !!xcto && !!rp;
+      record(
+        "X-Content-Type-Options / Referrer-Policy headers",
+        ok ? "PASS" : "PLATFORM-GATED",
+        ok
+          ? `x-content-type-options: ${xcto}, referrer-policy: ${rp}`
+          : `x-content-type-options: ${xcto ?? "(missing)"}, referrer-policy: ${rp ?? "(missing)"} — platform-controlled`,
+      );
+    }
+  }
+
+  // Cache-Control not no-store
+  {
+    const res = await fetchText(`${BASE_URL}/`);
+    if (res.error) {
+      record("Cache-Control not no-store", "PLATFORM-GATED", `network error — ${res.error}`);
+    } else {
+      const cc = res.headers.get("cache-control");
+      const noStore = !!cc && /no-store/i.test(cc);
+      record(
+        "Cache-Control not no-store",
+        noStore ? "PLATFORM-GATED" : "PASS",
+        `cache-control: ${cc ?? "(missing)"}${noStore ? " — platform-controlled" : ""}`,
+      );
+    }
+  }
+}
+
+async function main() {
+  console.log("=".repeat(78));
+  console.log("GEO / agent-discoverability signal check");
+  console.log(`Target: ${BASE_URL}`);
+  console.log(
+    "This script asserts the POST-MERGE, DEPLOYED target state.\n" +
+      "Redirect and rendered-HTML checks (and possibly llms.txt/llms-full.txt) are\n" +
+      "expected to FAIL if run against production before this PR stack has merged\n" +
+      "and Mintlify has rebuilt the site. That is not a regression.",
+  );
+  console.log("=".repeat(78));
+  console.log();
+
+  await checkLlmsTxt();
+  await checkLlmsFullTxt();
+  await checkRedirects();
+  await checkHtmlSignals();
+  await checkPlatformGated();
+
+  console.log();
+  console.log("=".repeat(78));
+  console.log("Summary");
+  console.log("=".repeat(78));
+
+  const counts = { PASS: 0, FAIL: 0, "PLATFORM-GATED": 0 } as Record<Status, number>;
+  for (const r of results) counts[r.status]++;
+
+  for (const r of results) {
+    console.log(`  [${r.status.padEnd(15, " ")}] ${r.name}`);
+  }
+
+  console.log();
+  console.log(`PASS: ${counts.PASS}  FAIL: ${counts.FAIL}  PLATFORM-GATED: ${counts["PLATFORM-GATED"]}`);
+
+  const failing = results.filter((r) => r.status === "FAIL");
+  if (failing.length > 0) {
+    console.log("\nNon-platform-gated failures (exit code will be non-zero):");
+    for (const r of failing) {
+      console.log(`  - ${r.name}: ${r.reason}`);
+    }
+    process.exit(1);
+  }
+
+  process.exit(0);
+}
+
+main().catch((err) => {
+  console.error("Unhandled error in check-geo-signals:", err);
+  process.exit(1);
+});

--- a/scripts/check-geo-signals.ts
+++ b/scripts/check-geo-signals.ts
@@ -57,6 +57,12 @@ async function fetchText(url: string, init?: RequestInit): Promise<{ ok: boolean
 // block rather than from a regex over the whole response body, so that a check
 // never depends on attribute order and never matches a marker that happens to
 // appear in prose, a code sample, or an embedded framework payload.
+//
+// Markup only counts when it is *active*. Before any tag is matched, HTML
+// comments and the text content of `<script>`/`<style>`/`<template>` are
+// removed, and the head-only signals are matched against `<head>` alone.
+// Otherwise a commented-out tag, or the same literal markup appearing inside
+// script text, would report PASS after the real signal had been deleted.
 
 type TagAttributes = Record<string, string>;
 
@@ -71,16 +77,37 @@ function parseAttributes(raw: string): TagAttributes {
   return attributes;
 }
 
-function findTags(html: string, tagName: string): TagAttributes[] {
-  const pattern = new RegExp(`<${tagName}\\b([^>]*)>`, "gi");
-  return [...html.matchAll(pattern)].map((match) => parseAttributes(match[1]));
+/** Commented-out markup is inert; a crawler never sees it, so neither should we. */
+function stripComments(html: string): string {
+  return html.replace(/<!--[\s\S]*?-->/g, "");
 }
 
-/** The parsed contents of every `<script type="application/ld+json">` block. */
+/**
+ * Removes the *text content* of elements whose contents are not markup, so that
+ * a tag written out inside script text (an inlined framework payload, a docs
+ * example) is not mistaken for a tag the document actually declares.
+ */
+function stripInertText(html: string): string {
+  return html.replace(/<(script|style|template)\b[^>]*>[\s\S]*?<\/\1\s*>/gi, "");
+}
+
+/** The `<head>` markup, or the whole document if no head can be located. */
+function headOf(html: string): string {
+  return /<head\b[^>]*>([\s\S]*?)<\/head\s*>/i.exec(html)?.[1] ?? html;
+}
+
+/** Active tags declared in `<head>` — comments and script/style text excluded. */
+function findHeadTags(html: string, tagName: string): TagAttributes[] {
+  const head = headOf(stripInertText(stripComments(html)));
+  const pattern = new RegExp(`<${tagName}\\b([^>]*)>`, "gi");
+  return [...head.matchAll(pattern)].map((match) => parseAttributes(match[1]));
+}
+
+/** The parsed contents of every active `<script type="application/ld+json">` block. */
 function parseJsonLdBlocks(html: string): unknown[] {
   const blocks: unknown[] = [];
   const scriptPattern = /<script\b([^>]*)>([\s\S]*?)<\/script\s*>/gi;
-  for (const match of html.matchAll(scriptPattern)) {
+  for (const match of stripComments(html).matchAll(scriptPattern)) {
     if (parseAttributes(match[1]).type?.trim().toLowerCase() !== "application/ld+json") continue;
     try {
       blocks.push(JSON.parse(match[2]));
@@ -240,7 +267,7 @@ async function checkHtmlSignals() {
       continue;
     }
 
-    const robotsContent = findTags(res.body, "meta")
+    const robotsContent = findHeadTags(res.body, "meta")
       .filter((attributes) => attributes.name?.toLowerCase() === "robots")
       .map((attributes) => attributes.content ?? "");
     const hasRobotsMeta = robotsContent.some((content) =>
@@ -299,7 +326,7 @@ async function checkPlatformGated() {
     const res = await fetchText(`${BASE_URL}/`);
     const hasLink =
       !res.error &&
-      findTags(res.body, "link").some(
+      findHeadTags(res.body, "link").some(
         (attributes) =>
           attributes.rel?.toLowerCase() === "alternate" &&
           attributes.type?.toLowerCase() === "text/plain" &&

--- a/scripts/check-geo-signals.ts
+++ b/scripts/check-geo-signals.ts
@@ -243,11 +243,13 @@ async function checkPlatformGated() {
       record("Cache-Control not no-store", "PLATFORM-GATED", `network error — ${res.error}`);
     } else {
       const cc = res.headers.get("cache-control");
-      const noStore = !!cc && /no-store/i.test(cc);
+      // A missing header is not a pass: without an explicit cacheable
+      // directive we cannot claim the signal is configured.
+      const cacheable = !!cc && !/no-store/i.test(cc);
       record(
         "Cache-Control not no-store",
-        noStore ? "PLATFORM-GATED" : "PASS",
-        `cache-control: ${cc ?? "(missing)"}${noStore ? " — platform-controlled" : ""}`,
+        cacheable ? "PASS" : "PLATFORM-GATED",
+        `cache-control: ${cc ?? "(missing)"}${cacheable ? "" : " — platform-controlled"}`,
       );
     }
   }

--- a/scripts/check-geo-signals.ts
+++ b/scripts/check-geo-signals.ts
@@ -20,10 +20,12 @@
  * Exit code is non-zero only if a non-platform-gated check fails.
  */
 
+import { readFileSync } from "node:fs";
+
 const DEFAULT_BASE_URL = "https://docs.request.network";
 const BASE_URL = (process.argv[2] || process.env.BASE_URL || DEFAULT_BASE_URL).replace(/\/$/, "");
 
-type Status = "PASS" | "FAIL" | "PLATFORM-GATED";
+type Status = "PASS" | "FAIL" | "PLATFORM-GATED" | "INFO";
 
 type Result = {
   name: string;
@@ -46,6 +48,89 @@ async function fetchText(url: string, init?: RequestInit): Promise<{ ok: boolean
     return { ok: res.ok, status: res.status, body, headers: res.headers };
   } catch (err) {
     return { ok: false, status: 0, body: "", headers: new Headers(), error: (err as Error).message };
+  }
+}
+
+// --- HTML parsing helpers ---
+//
+// Every HTML signal below is read from a *parsed* tag or a *parsed* JSON-LD
+// block rather than from a regex over the whole response body, so that a check
+// never depends on attribute order and never matches a marker that happens to
+// appear in prose, a code sample, or an embedded framework payload.
+
+type TagAttributes = Record<string, string>;
+
+const ATTRIBUTE_PATTERN =
+  /([a-zA-Z_:][-a-zA-Z0-9_:.]*)(?:\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s"'`=<>]+)))?/g;
+
+function parseAttributes(raw: string): TagAttributes {
+  const attributes: TagAttributes = {};
+  for (const match of raw.matchAll(ATTRIBUTE_PATTERN)) {
+    attributes[match[1].toLowerCase()] = match[2] ?? match[3] ?? match[4] ?? "";
+  }
+  return attributes;
+}
+
+function findTags(html: string, tagName: string): TagAttributes[] {
+  const pattern = new RegExp(`<${tagName}\\b([^>]*)>`, "gi");
+  return [...html.matchAll(pattern)].map((match) => parseAttributes(match[1]));
+}
+
+/** The parsed contents of every `<script type="application/ld+json">` block. */
+function parseJsonLdBlocks(html: string): unknown[] {
+  const blocks: unknown[] = [];
+  const scriptPattern = /<script\b([^>]*)>([\s\S]*?)<\/script\s*>/gi;
+  for (const match of html.matchAll(scriptPattern)) {
+    if (parseAttributes(match[1]).type?.trim().toLowerCase() !== "application/ld+json") continue;
+    try {
+      blocks.push(JSON.parse(match[2]));
+    } catch {
+      // A block that isn't valid JSON carries no structured-data signal.
+    }
+  }
+  return blocks;
+}
+
+/**
+ * The nodes a JSON-LD block actually declares: the block itself, the members of
+ * a top-level array, and the members of any `@graph`.
+ *
+ * Deliberately *not* a recursive walk of every property. Mintlify's stock
+ * `WebSite` block nests `{"@type":"Organization","name":"Mintlify"}` under
+ * `creator`, so counting nested nodes would let the Organization check pass on
+ * any Mintlify site regardless of our own structured data.
+ */
+function declaredNodes(block: unknown): Record<string, unknown>[] {
+  const nodes: Record<string, unknown>[] = [];
+  const visit = (value: unknown) => {
+    if (Array.isArray(value)) {
+      for (const entry of value) visit(entry);
+      return;
+    }
+    if (!value || typeof value !== "object") return;
+    const node = value as Record<string, unknown>;
+    nodes.push(node);
+    if ("@graph" in node) visit(node["@graph"]);
+  };
+  visit(block);
+  return nodes;
+}
+
+function hasType(node: Record<string, unknown>, type: string): boolean {
+  const declared = node["@type"];
+  return Array.isArray(declared) ? declared.includes(type) : declared === type;
+}
+
+/** `seo.organization` from docs.json — the organization identity this repo configures. */
+function configuredOrganization(): { id?: string; name?: string; url?: string } {
+  try {
+    const raw = readFileSync(new URL("../docs.json", import.meta.url), "utf8");
+    const config = JSON.parse(raw) as {
+      seo?: { organization?: { id?: string; name?: string; url?: string } };
+    };
+    return config.seo?.organization ?? {};
+  } catch {
+    return {};
   }
 }
 
@@ -138,6 +223,11 @@ async function checkRedirects() {
 const PAGES_TO_CHECK = ["/", "/use-cases/no-code-payment-links"];
 
 async function checkHtmlSignals() {
+  const configured = configuredOrganization();
+  const expectedIdentity = [configured.id, configured.url, configured.name].filter(
+    (value): value is string => !!value,
+  );
+
   for (const path of PAGES_TO_CHECK) {
     const url = `${BASE_URL}${path}`;
     const res = await fetchText(url);
@@ -150,20 +240,55 @@ async function checkHtmlSignals() {
       continue;
     }
 
-    const hasRobotsMeta =
-      /<meta[^>]+name=["']robots["'][^>]*content=["'][^"']*max-snippet:-1[^"']*["']/i.test(res.body);
+    const robotsContent = findTags(res.body, "meta")
+      .filter((attributes) => attributes.name?.toLowerCase() === "robots")
+      .map((attributes) => attributes.content ?? "");
+    const hasRobotsMeta = robotsContent.some((content) =>
+      content.toLowerCase().includes("max-snippet:-1"),
+    );
     record(
       `${path} robots meta max-snippet:-1`,
       hasRobotsMeta ? "PASS" : "FAIL",
-      hasRobotsMeta ? "found in <head>" : "not found",
+      hasRobotsMeta
+        ? "found in <head>"
+        : robotsContent.length > 0
+          ? `robots meta present without max-snippet:-1 — content: ${robotsContent.join(" | ")}`
+          : "no robots meta tag found",
     );
 
-    const hasOrgJsonLd = /"@type"\s*:\s*"Organization"/.test(res.body);
+    const organizations = parseJsonLdBlocks(res.body)
+      .flatMap(declaredNodes)
+      .filter((node) => hasType(node, "Organization"));
     record(
       `${path} Organization JSON-LD`,
-      hasOrgJsonLd ? "PASS" : "FAIL",
-      hasOrgJsonLd ? 'found "@type":"Organization"' : "not found",
+      organizations.length > 0 ? "PASS" : "FAIL",
+      organizations.length > 0
+        ? `declared in application/ld+json — ${organizations
+            .map((node) => String(node["@id"] ?? node.url ?? node.name ?? "(unidentified)"))
+            .join(", ")}`
+        : "no Organization node declared in any application/ld+json block",
     );
+
+    // Mintlify emits a default Organization derived from docs.json "name", so the
+    // presence check above can be satisfied by platform defaults alone. This line
+    // reports whether the identity configured in docs.json seo.organization is the
+    // one actually being served. It never fails the run: whether Mintlify honours
+    // seo.organization over its own default is platform behaviour we have not
+    // confirmed, so a mismatch is reported rather than asserted.
+    if (expectedIdentity.length > 0) {
+      const matched = organizations.find((node) =>
+        expectedIdentity.some(
+          (value) => node["@id"] === value || node.url === value || node.name === value,
+        ),
+      );
+      record(
+        `${path} Organization matches docs.json seo.organization`,
+        matched ? "PASS" : "INFO",
+        matched
+          ? `@id ${String(matched["@id"] ?? "(none)")}, name ${String(matched.name ?? "(none)")}`
+          : `no Organization node carries ${expectedIdentity.join(" / ")} — only Mintlify's default organization data is being served`,
+      );
+    }
   }
 }
 
@@ -174,7 +299,12 @@ async function checkPlatformGated() {
     const res = await fetchText(`${BASE_URL}/`);
     const hasLink =
       !res.error &&
-      /<link[^>]+rel=["']alternate["'][^>]+type=["']text\/plain["'][^>]+href=["']\/llms\.txt["']/i.test(res.body);
+      findTags(res.body, "link").some(
+        (attributes) =>
+          attributes.rel?.toLowerCase() === "alternate" &&
+          attributes.type?.toLowerCase() === "text/plain" &&
+          attributes.href === "/llms.txt",
+      );
     record(
       '<link rel="alternate" type="text/plain" href="/llms.txt">',
       hasLink ? "PASS" : "PLATFORM-GATED",
@@ -279,7 +409,7 @@ async function main() {
   console.log("Summary");
   console.log("=".repeat(78));
 
-  const counts = { PASS: 0, FAIL: 0, "PLATFORM-GATED": 0 } as Record<Status, number>;
+  const counts = { PASS: 0, FAIL: 0, "PLATFORM-GATED": 0, INFO: 0 } as Record<Status, number>;
   for (const r of results) counts[r.status]++;
 
   for (const r of results) {
@@ -287,7 +417,9 @@ async function main() {
   }
 
   console.log();
-  console.log(`PASS: ${counts.PASS}  FAIL: ${counts.FAIL}  PLATFORM-GATED: ${counts["PLATFORM-GATED"]}`);
+  console.log(
+    `PASS: ${counts.PASS}  FAIL: ${counts.FAIL}  PLATFORM-GATED: ${counts["PLATFORM-GATED"]}  INFO: ${counts.INFO}`,
+  );
 
   const failing = results.filter((r) => r.status === "FAIL");
   if (failing.length > 0) {


### PR DESCRIPTION
Addresses [REQ-169](https://linear.app/requestnetwork/issue/REQ-169/verification-claude-builds-a-payment-link-from-docs-alone-geo-re-check). Stacked on #109.

The MVP's done condition is that an AI agent can integrate Request from the docs alone. That was never checkable on demand. This adds the instrument; **running the live UAT is a separate post-deploy step** and the results log is deliberately empty apart from the baseline.

## `VALIDATION.md`

1. **The docs-only LLM check** — the exact prompt to paste into a fresh session with web access only, plus a pass/fail rubric built from the specific failure modes this project exists to prevent: asking for an API key, private key or raw wallet address; fulfilling on `payment.partial`; treating a cross-chain payment as final on redirect; reaching for an SDK that doesn't exist; verifying the webhook HMAC against a re-serialized body. One violation fails the run.
2. **The automated signal check** (below).
3. `mint broken-links` and `mint validate`.
4. **The external GEO re-check** — Outrun (baseline: grade C, 172/257) and `mint score docs.request.network`, which needs an interactive `mint login` and so is marked a human step, never CI.

Note the rubric treats *asking for the Destination ID* as **correct, not a failure** — #106 establishes that it's a non-secret identifier the user copies from the Dashboard.

## `scripts/check-geo-signals.ts`

Node built-ins only, no new dependencies, follows `scripts/capture-screenshots.ts`. Run with `pnpm check-geo-signals` (or `BASE_URL=... npx tsx scripts/check-geo-signals.ts`).

Signals Mintlify controls report as **PLATFORM-GATED** and never fail the run, so the REQ-271 platform gap can't be misread as a repo regression.

**First run against production, pre-merge, already earns its keep:**

```
PASS   redirect /api-features/no-code-payment-links      — 308 -> /use-cases/no-code-payment-links
PASS   redirect /api-features/programmatic-payment-links — 308 -> /use-cases/programmatic-payment-links
PASS   redirect /api-features/authentication             — 308 -> /api-reference/authentication
PASS   / Organization JSON-LD — found "@type":"Organization"
FAIL   / robots meta max-snippet:-1 — not found
PLATFORM-GATED  Cache-Control not no-store — cache-control: no-store, no-cache, ...
PLATFORM-GATED  robots.txt per-bot Allow lines — missing GPTBot, OAI-SearchBot, ClaudeBot, PerplexityBot, Google-Extended
PLATFORM-GATED  /.well-known/security.txt — 404
```

Three things that confirms: REQ-159's redirects are genuinely live; the `robots` metatag from #106 is not deployed yet (expected — the stack is unmerged, which is exactly what the script's header warns about); and `Cache-Control: no-store` is real, which is the measured evidence behind the performance half of REQ-270.

## Verification

- `npx tsx scripts/check-geo-signals.ts` — runs to completion, exits 1 pre-merge as designed, no crash
- `mint validate` — passes; `mint broken-links` — clean
- `VALIDATION.md` is not added to `docs.json` navigation — it's a repo document, not a published page
