### PR TITLE
fix: redirect 99 dead GitBook-era paths (REQ-285)

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -45,6 +45,402 @@
     {
       "source": "/api-features/authentication",
       "destination": "/api-reference/authentication"
+    },
+    {
+      "source": "/advanced/introduction-to-the-request-protocol",
+      "destination": "/use-cases/welcome"
+    },
+    {
+      "source": "/advanced/introduction-to-the-request-protocol/advanced-logic",
+      "destination": "/use-cases/welcome"
+    },
+    {
+      "source": "/advanced/introduction-to-the-request-protocol/data-access",
+      "destination": "/use-cases/welcome"
+    },
+    {
+      "source": "/advanced/introduction-to-the-request-protocol/request-logic",
+      "destination": "/use-cases/welcome"
+    },
+    {
+      "source": "/advanced/introduction-to-the-request-protocol/storage",
+      "destination": "/use-cases/welcome"
+    },
+    {
+      "source": "/advanced/introduction-to-the-request-protocol/transaction",
+      "destination": "/use-cases/welcome"
+    },
+    {
+      "source": "/advanced/protocol-overview",
+      "destination": "/use-cases/welcome"
+    },
+    {
+      "source": "/advanced/protocol-overview/contracts",
+      "destination": "/use-cases/welcome"
+    },
+    {
+      "source": "/advanced/protocol-overview/how-payment-networks-work",
+      "destination": "/use-cases/welcome"
+    },
+    {
+      "source": "/advanced/protocol-overview/private-requests-using-encryption",
+      "destination": "/use-cases/welcome"
+    },
+    {
+      "source": "/advanced/request-network-sdk/get-started",
+      "destination": "/use-cases/welcome"
+    },
+    {
+      "source": "/advanced/request-network-sdk/get-started/installation",
+      "destination": "/use-cases/welcome"
+    },
+    {
+      "source": "/advanced/request-network-sdk/get-started/quickstart-browser",
+      "destination": "/use-cases/welcome"
+    },
+    {
+      "source": "/advanced/request-network-sdk/get-started/request-node-gateways",
+      "destination": "/use-cases/welcome"
+    },
+    {
+      "source": "/advanced/request-network-sdk/get-started/sdk-injector",
+      "destination": "/use-cases/welcome"
+    },
+    {
+      "source": "/advanced/request-network-sdk/sdk-api-reference",
+      "destination": "/use-cases/welcome"
+    },
+    {
+      "source": "/advanced/request-network-sdk/sdk-api-reference/epk-decryption/ethereumprivatekeydecryptionprovider",
+      "destination": "/use-cases/welcome"
+    },
+    {
+      "source": "/advanced/request-network-sdk/sdk-api-reference/epk-signature",
+      "destination": "/use-cases/welcome"
+    },
+    {
+      "source": "/advanced/request-network-sdk/sdk-api-reference/payment-processor",
+      "destination": "/use-cases/welcome"
+    },
+    {
+      "source": "/advanced/request-network-sdk/sdk-api-reference/payment-processor/payrequest",
+      "destination": "/use-cases/welcome"
+    },
+    {
+      "source": "/advanced/request-network-sdk/sdk-api-reference/request-client.js/iidentity",
+      "destination": "/use-cases/welcome"
+    },
+    {
+      "source": "/advanced/request-network-sdk/sdk-api-reference/request-client.js/irequestdatawithevents",
+      "destination": "/use-cases/welcome"
+    },
+    {
+      "source": "/advanced/request-network-sdk/sdk-api-reference/request-client.js/paymentreferencecalculator",
+      "destination": "/use-cases/welcome"
+    },
+    {
+      "source": "/advanced/request-network-sdk/sdk-api-reference/request-client.js/request/cancel",
+      "destination": "/use-cases/welcome"
+    },
+    {
+      "source": "/advanced/request-network-sdk/sdk-api-reference/request-client.js/request/getdata",
+      "destination": "/use-cases/welcome"
+    },
+    {
+      "source": "/advanced/request-network-sdk/sdk-api-reference/request-client.js/request/increaseexpectedamountrequest",
+      "destination": "/use-cases/welcome"
+    },
+    {
+      "source": "/advanced/request-network-sdk/sdk-api-reference/request-client.js/request/refresh",
+      "destination": "/use-cases/welcome"
+    },
+    {
+      "source": "/advanced/request-network-sdk/sdk-api-reference/request-client.js/request/waitforconfirmation",
+      "destination": "/use-cases/welcome"
+    },
+    {
+      "source": "/advanced/request-network-sdk/sdk-api-reference/request-client.js/requestnetwork",
+      "destination": "/use-cases/welcome"
+    },
+    {
+      "source": "/advanced/request-network-sdk/sdk-api-reference/request-client.js/requestnetwork/fromrequestid",
+      "destination": "/use-cases/welcome"
+    },
+    {
+      "source": "/advanced/request-network-sdk/sdk-api-reference/web3-signature",
+      "destination": "/use-cases/welcome"
+    },
+    {
+      "source": "/advanced/request-network-sdk/sdk-demo-apps",
+      "destination": "/use-cases/welcome"
+    },
+    {
+      "source": "/advanced/request-network-sdk/sdk-demo-apps/components",
+      "destination": "/use-cases/welcome"
+    },
+    {
+      "source": "/advanced/request-network-sdk/sdk-demo-apps/components/add-stakeholder",
+      "destination": "/use-cases/welcome"
+    },
+    {
+      "source": "/advanced/request-network-sdk/sdk-demo-apps/components/create-invoice-form",
+      "destination": "/use-cases/welcome"
+    },
+    {
+      "source": "/advanced/request-network-sdk/sdk-demo-apps/components/initializeRN",
+      "destination": "/use-cases/welcome"
+    },
+    {
+      "source": "/advanced/request-network-sdk/sdk-demo-apps/request-checkout",
+      "destination": "/use-cases/welcome"
+    },
+    {
+      "source": "/advanced/request-network-sdk/sdk-demo-apps/request-invoicing",
+      "destination": "/use-cases/welcome"
+    },
+    {
+      "source": "/advanced/request-network-sdk/sdk-guides",
+      "destination": "/use-cases/welcome"
+    },
+    {
+      "source": "/advanced/request-network-sdk/sdk-guides/encryption-and-decryption",
+      "destination": "/use-cases/welcome"
+    },
+    {
+      "source": "/advanced/request-network-sdk/sdk-guides/encryption-and-decryption/handle-encryption-with-a-web3-wallet",
+      "destination": "/use-cases/welcome"
+    },
+    {
+      "source": "/advanced/request-network-sdk/sdk-guides/encryption-and-decryption/handling-encryption-with-the-js-library",
+      "destination": "/use-cases/welcome"
+    },
+    {
+      "source": "/advanced/request-network-sdk/sdk-guides/encryption-and-decryption/share-an-encrypted-request",
+      "destination": "/use-cases/welcome"
+    },
+    {
+      "source": "/advanced/request-network-sdk/sdk-guides/mobile-using-expo",
+      "destination": "/use-cases/welcome"
+    },
+    {
+      "source": "/advanced/request-network-sdk/sdk-guides/payment",
+      "destination": "/use-cases/welcome"
+    },
+    {
+      "source": "/advanced/request-network-sdk/sdk-guides/payment/batch-payment",
+      "destination": "/api-features/batch-payments"
+    },
+    {
+      "source": "/advanced/request-network-sdk/sdk-guides/payment/conversion-request",
+      "destination": "/api-features/conversion-payments"
+    },
+    {
+      "source": "/advanced/request-network-sdk/sdk-guides/payment/declarative-request",
+      "destination": "/use-cases/welcome"
+    },
+    {
+      "source": "/advanced/request-network-sdk/sdk-guides/payment/escrow-request",
+      "destination": "/use-cases/welcome"
+    },
+    {
+      "source": "/advanced/request-network-sdk/sdk-guides/payment/hinkal-private-payments",
+      "destination": "/use-cases/welcome"
+    },
+    {
+      "source": "/advanced/request-network-sdk/sdk-guides/payment/meta-payments",
+      "destination": "/use-cases/welcome"
+    },
+    {
+      "source": "/advanced/request-network-sdk/sdk-guides/payment/native-payment",
+      "destination": "/api-features/standard-payments"
+    },
+    {
+      "source": "/advanced/request-network-sdk/sdk-guides/payment/pay-through-a-proxy-contract-with-a-multisig",
+      "destination": "/use-cases/welcome"
+    },
+    {
+      "source": "/advanced/request-network-sdk/sdk-guides/payment/shared",
+      "destination": "/use-cases/welcome"
+    },
+    {
+      "source": "/advanced/request-network-sdk/sdk-guides/payment/single-request-forwarder",
+      "destination": "/use-cases/welcome"
+    },
+    {
+      "source": "/advanced/request-network-sdk/sdk-guides/payment/streaming-request",
+      "destination": "/use-cases/welcome"
+    },
+    {
+      "source": "/advanced/request-network-sdk/sdk-guides/payment/swap-to-pay-request",
+      "destination": "/use-cases/welcome"
+    },
+    {
+      "source": "/advanced/request-network-sdk/sdk-guides/payment/transferable-receivable-payment",
+      "destination": "/use-cases/welcome"
+    },
+    {
+      "source": "/advanced/request-network-sdk/sdk-guides/request-client",
+      "destination": "/use-cases/welcome"
+    },
+    {
+      "source": "/advanced/request-network-sdk/sdk-guides/request-client/retrieve-a-request",
+      "destination": "/use-cases/welcome"
+    },
+    {
+      "source": "/advanced/request-network-sdk/sdk-guides/request-client/support-a-new-currency",
+      "destination": "/use-cases/welcome"
+    },
+    {
+      "source": "/advanced/request-network-sdk/sdk-guides/request-client/updating-a-request",
+      "destination": "/use-cases/welcome"
+    },
+    {
+      "source": "/api-setup/components/create-payment",
+      "destination": "/use-cases/welcome"
+    },
+    {
+      "source": "/contribute/request-fund/how-to-apply",
+      "destination": "/use-cases/welcome"
+    },
+    {
+      "source": "/development/guides/online-payments",
+      "destination": "/use-cases/welcome"
+    },
+    {
+      "source": "/development/protocol",
+      "destination": "/use-cases/welcome"
+    },
+    {
+      "source": "/docs/guides/1-first-request",
+      "destination": "/use-cases/quickstart"
+    },
+    {
+      "source": "/docs/guides/7-protocol/5-flows",
+      "destination": "/use-cases/welcome"
+    },
+    {
+      "source": "/general/lifecycle-of-a-request",
+      "destination": "/resources/lifecycle-of-a-request"
+    },
+    {
+      "source": "/general/request-network-token-list",
+      "destination": "/resources/token-list"
+    },
+    {
+      "source": "/general/request-scan",
+      "destination": "/tools/dashboard"
+    },
+    {
+      "source": "/general/supported-chains",
+      "destination": "/resources/supported-chains-and-currencies"
+    },
+    {
+      "source": "/general/supported-chains/smart-contract-addresses",
+      "destination": "/resources/supported-chains-and-currencies"
+    },
+    {
+      "source": "/get-started/request-node-gateways",
+      "destination": "/use-cases/welcome"
+    },
+    {
+      "source": "/img/request_docs_thumbnail.png",
+      "destination": "/use-cases/welcome"
+    },
+    {
+      "source": "/learn-request-network/introduction-to-the-request-protocol",
+      "destination": "/use-cases/welcome"
+    },
+    {
+      "source": "/payments",
+      "destination": "/use-cases/welcome"
+    },
+    {
+      "source": "/request-fund",
+      "destination": "/use-cases/welcome"
+    },
+    {
+      "source": "/request-network-api/api-portal-manage-api-keys-and-webhooks",
+      "destination": "/api-features/client-id-management"
+    },
+    {
+      "source": "/request-network-api/batch-payments",
+      "destination": "/api-features/batch-payments"
+    },
+    {
+      "source": "/request-network-api/components/view-payments",
+      "destination": "/api-features/query-payments"
+    },
+    {
+      "source": "/request-network-api/create-and-pay-requests",
+      "destination": "/api-features/create-requests"
+    },
+    {
+      "source": "/request-network-api/crosschain-payments",
+      "destination": "/api-features/crosschain-payments"
+    },
+    {
+      "source": "/request-network-api/crypto-to-fiat-payments",
+      "destination": "/api-features/crypto-to-fiat-payments"
+    },
+    {
+      "source": "/request-network-api/easyinvoice-api-demo-app",
+      "destination": "/use-cases/quickstart"
+    },
+    {
+      "source": "/request-network-api/fees",
+      "destination": "/api-features/fee-breakdowns"
+    },
+    {
+      "source": "/request-network-api/integration-tutorial",
+      "destination": "/api-setup/integration-tutorial"
+    },
+    {
+      "source": "/request-network-api/migrate-to-v2",
+      "destination": "/api-setup/getting-started"
+    },
+    {
+      "source": "/request-network-api/payment-detection",
+      "destination": "/api-features/payment-detection"
+    },
+    {
+      "source": "/request-network-api/recurring-payments",
+      "destination": "/api-features/recurring-payments"
+    },
+    {
+      "source": "/request-network-api/supported-chains-and-currencies",
+      "destination": "/resources/supported-chains-and-currencies"
+    },
+    {
+      "source": "/sdk-guides/payment/native-payment",
+      "destination": "/api-features/standard-payments"
+    },
+    {
+      "source": "/sdk-guides/request-client/updating-a-request",
+      "destination": "/use-cases/welcome"
+    },
+    {
+      "source": "/v2/commerce-payments",
+      "destination": "/api-features/commerce-payments"
+    },
+    {
+      "source": "/v2/payee-destination",
+      "destination": "/api-features/payee-destinations"
+    },
+    {
+      "source": "/v2/payee-destination/signing-data",
+      "destination": "/api-reference/v2payee-destination/get-eip-712-signing-data-with-nonce"
+    },
+    {
+      "source": "/v2/payouts",
+      "destination": "/api-features/payouts"
+    },
+    {
+      "source": "/v2/payouts/batch",
+      "destination": "/api-features/payouts"
+    },
+    {
+      "source": "/webhooks",
+      "destination": "/api-features/webhooks-events"
     }
   ],
   "navigation": {


### PR DESCRIPTION
Closes the docs.request.network half of [REQ-285](https://linear.app/requestnetwork/issue/REQ-285/fix-broken-links-in-our-docs). Top of the stack — stacked on #110.

Adds **99 redirects** for dead paths from the SEO audit's broken-link export. All of them 404 today; most are GitBook-era URLs and pages from the removed SDK section.

70 of the 99 point at `/use-cases/welcome` because their section no longer exists — chiefly `/advanced/request-network-sdk/**`, the retired SDK docs. The remaining 29 map to a specific live page (`/request-network-api/crosschain-payments` → `/api-features/crosschain-payments`, `/general/request-scan` → `/tools/dashboard`, and so on). The mapping is the audit file's, not mine.

## Verified before committing

| Check | Result |
| --- | --- |
| Every source currently 404s and shadows no live page | ✅ no working URL changes behavior |
| Every destination resolves | ✅ 23 local `.mdx`; the 24th is OpenAPI-generated and returns 200 in production |
| Duplicate sources | ✅ none |
| Redirect chains (a destination that is itself a source) | ✅ none |
| `mint validate` / `mint broken-links` | ✅ pass / clean |

Two things worth knowing about the shape of this diff:

**Why 99 rows instead of a few wildcards.** Mintlify's `redirects` takes literal paths only — there is no `/advanced/:slug*` form ([settings reference](https://www.mintlify.com/docs/organize/settings-reference)). 62 of these share the `/advanced` prefix and would collapse to one line if wildcards existed. If Mintlify ever adds them, this block shrinks dramatically.

**`permanent` is left unset**, which defaults to `true` (308) — matching the three existing entries and what an SEO audit wants.

## Bonus: two of the "5XX" URLs are fixed here

The audit's second file lists 145 URLs returning 5XX. Two of them are docs pages that also appear on this redirect list — `/advanced/protocol-overview/contracts` and `/advanced/introduction-to-the-request-protocol/advanced-logic` — so they're resolved by this PR.

## Out of scope (flagged, not silently dropped)

- **5 `legacy.docs.request.network` paths** in the same export. Different deployment; `docs.json` cannot redirect another host.
- **143 `scan.request.network` / `scan.stage.request.network` 5XX URLs.** A different service returning server errors, not missing redirects — no redirect config fixes them.
- **11 of those are on `scan.stage.request.network`** — a staging host that is publicly crawlable and being indexed. That's its own problem (staging in the search index, duplicate content) and probably wants a `noindex` or auth in front of it. Raised on the Linear issue.

## Two mappings I kept but would flag to the author

- `/general/request-scan` → `/tools/dashboard`. Request Scan is a distinct product (scan.request.network) and the Dashboard page isn't really about it; there's just no live Request Scan page to point at. Reasonable, but it's a judgment call, not an equivalence.
- `/img/request_docs_thumbnail.png` → `/use-cases/welcome`. Redirecting an image asset to an HTML page is odd, though harmless — it was a crawled 404.
