### PR TITLE
fix: refine historical docs redirects (REQ-285)

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -48,7 +48,7 @@
     },
     {
       "source": "/advanced/introduction-to-the-request-protocol",
-      "destination": "/use-cases/welcome"
+      "destination": "/resources/lifecycle-of-a-request"
     },
     {
       "source": "/advanced/introduction-to-the-request-protocol/advanced-logic",
@@ -72,7 +72,7 @@
     },
     {
       "source": "/advanced/protocol-overview",
-      "destination": "/use-cases/welcome"
+      "destination": "/resources/lifecycle-of-a-request"
     },
     {
       "source": "/advanced/protocol-overview/contracts",
@@ -80,7 +80,7 @@
     },
     {
       "source": "/advanced/protocol-overview/how-payment-networks-work",
-      "destination": "/use-cases/welcome"
+      "destination": "/resources/lifecycle-of-a-request"
     },
     {
       "source": "/advanced/protocol-overview/private-requests-using-encryption",
@@ -88,15 +88,15 @@
     },
     {
       "source": "/advanced/request-network-sdk/get-started",
-      "destination": "/use-cases/welcome"
+      "destination": "/api-setup/getting-started"
     },
     {
       "source": "/advanced/request-network-sdk/get-started/installation",
-      "destination": "/use-cases/welcome"
+      "destination": "/api-setup/getting-started"
     },
     {
       "source": "/advanced/request-network-sdk/get-started/quickstart-browser",
-      "destination": "/use-cases/welcome"
+      "destination": "/api-setup/getting-started"
     },
     {
       "source": "/advanced/request-network-sdk/get-started/request-node-gateways",
@@ -224,7 +224,7 @@
     },
     {
       "source": "/advanced/request-network-sdk/sdk-guides/payment",
-      "destination": "/use-cases/welcome"
+      "destination": "/api-features/payment-types-overview"
     },
     {
       "source": "/advanced/request-network-sdk/sdk-guides/payment/batch-payment",
@@ -256,7 +256,7 @@
     },
     {
       "source": "/advanced/request-network-sdk/sdk-guides/payment/pay-through-a-proxy-contract-with-a-multisig",
-      "destination": "/use-cases/welcome"
+      "destination": "/api-features/safe-multisig-payments"
     },
     {
       "source": "/advanced/request-network-sdk/sdk-guides/payment/shared",
@@ -272,7 +272,7 @@
     },
     {
       "source": "/advanced/request-network-sdk/sdk-guides/payment/swap-to-pay-request",
-      "destination": "/use-cases/welcome"
+      "destination": "/api-features/crosschain-payments"
     },
     {
       "source": "/advanced/request-network-sdk/sdk-guides/payment/transferable-receivable-payment",
@@ -284,7 +284,7 @@
     },
     {
       "source": "/advanced/request-network-sdk/sdk-guides/request-client/retrieve-a-request",
-      "destination": "/use-cases/welcome"
+      "destination": "/api-features/query-requests"
     },
     {
       "source": "/advanced/request-network-sdk/sdk-guides/request-client/support-a-new-currency",
@@ -296,19 +296,15 @@
     },
     {
       "source": "/api-setup/components/create-payment",
-      "destination": "/use-cases/welcome"
-    },
-    {
-      "source": "/contribute/request-fund/how-to-apply",
-      "destination": "/use-cases/welcome"
+      "destination": "/api-setup/getting-started"
     },
     {
       "source": "/development/guides/online-payments",
-      "destination": "/use-cases/welcome"
+      "destination": "/use-cases/programmatic-payment-links"
     },
     {
       "source": "/development/protocol",
-      "destination": "/use-cases/welcome"
+      "destination": "/resources/lifecycle-of-a-request"
     },
     {
       "source": "/docs/guides/1-first-request",
@@ -316,7 +312,7 @@
     },
     {
       "source": "/docs/guides/7-protocol/5-flows",
-      "destination": "/use-cases/welcome"
+      "destination": "/resources/lifecycle-of-a-request"
     },
     {
       "source": "/general/lifecycle-of-a-request",
@@ -328,7 +324,7 @@
     },
     {
       "source": "/general/request-scan",
-      "destination": "/tools/dashboard"
+      "destination": "https://scan.request.network"
     },
     {
       "source": "/general/supported-chains",
@@ -343,20 +339,12 @@
       "destination": "/use-cases/welcome"
     },
     {
-      "source": "/img/request_docs_thumbnail.png",
-      "destination": "/use-cases/welcome"
-    },
-    {
       "source": "/learn-request-network/introduction-to-the-request-protocol",
-      "destination": "/use-cases/welcome"
+      "destination": "/resources/lifecycle-of-a-request"
     },
     {
       "source": "/payments",
-      "destination": "/use-cases/welcome"
-    },
-    {
-      "source": "/request-fund",
-      "destination": "/use-cases/welcome"
+      "destination": "/api-features/payment-types-overview"
     },
     {
       "source": "/request-network-api/api-portal-manage-api-keys-and-webhooks",


### PR DESCRIPTION
# Problem

PR #112 adds redirects for historical GitBook URLs, but several clear successors still point to the generic welcome page or an unrelated product. Other removed URLs have no current successor and should keep the site's useful 404.

# Proposed Solution

Refine the high-confidence mappings in `docs.json`:

- Send historical protocol overview pages to the current request lifecycle page.
- Send payment overview, setup, create-payment, swap-to-pay, Safe multisig, request retrieval, and online payment guides to their closest current pages.
- Send the historical Request Scan path to `https://scan.request.network`.
- Keep the old smart-contract-address path pointed at the supported chains and currencies page as the closest supported resource.
- Remove redirects for Request Fund and an obsolete image asset so they return the helpful 404.
- Keep retired SDK references without a clear successor on the existing welcome fallback.

# UAT

1. Open the Mintlify preview deployment.
2. Confirm these historical paths redirect to the stated destinations:
   - `/payments` -> `/api-features/payment-types-overview`
   - `/advanced/request-network-sdk/get-started` -> `/api-setup/getting-started`
   - `/advanced/request-network-sdk/sdk-guides/payment` -> `/api-features/payment-types-overview`
   - `/api-setup/components/create-payment` -> `/api-setup/getting-started`
   - `/advanced/request-network-sdk/sdk-guides/payment/swap-to-pay-request` -> `/api-features/crosschain-payments`
   - `/advanced/request-network-sdk/sdk-guides/payment/pay-through-a-proxy-contract-with-a-multisig` -> `/api-features/safe-multisig-payments`
   - `/advanced/request-network-sdk/sdk-guides/request-client/retrieve-a-request` -> `/api-features/query-requests`
   - `/development/guides/online-payments` -> `/use-cases/programmatic-payment-links`
   - `/advanced/introduction-to-the-request-protocol` -> `/resources/lifecycle-of-a-request`
   - `/advanced/protocol-overview` -> `/resources/lifecycle-of-a-request`
   - `/advanced/protocol-overview/how-payment-networks-work` -> `/resources/lifecycle-of-a-request`
   - `/development/protocol` -> `/resources/lifecycle-of-a-request`
   - `/docs/guides/7-protocol/5-flows` -> `/resources/lifecycle-of-a-request`
   - `/learn-request-network/introduction-to-the-request-protocol` -> `/resources/lifecycle-of-a-request`
   - `/general/supported-chains/smart-contract-addresses` -> `/resources/supported-chains-and-currencies`
   - `/general/request-scan` -> `https://scan.request.network`
3. Confirm these paths show the site's helpful 404:
   - `/request-fund`
   - `/contribute/request-fund/how-to-apply`
   - `/img/request_docs_thumbnail.png`
4. Confirm a retired SDK reference without a current successor, such as `/advanced/request-network-sdk/sdk-api-reference/request-client.js/iidentity`, still redirects to `/use-cases/welcome`.

# Validation

- `mint validate`
- `mint broken-links --check-redirects`
- JSON parsing, duplicate-source detection, and target-file checks

# Considerations

- This PR is stacked on #112 and only refines redirects introduced there.
- The smart-contract-address redirect leads to the closest supported documentation without exposing the implementation contract list.
- The blanket `legacy.docs.request.network` Cloudflare redirect is unchanged.
- Pricing content is unchanged.

Linear: [REQ-285](https://linear.app/requestnetwork/issue/REQ-285)
